### PR TITLE
Replace Clerk with first‑party JWT auth; add user management and Clerk→Auth migration

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -286,3 +286,28 @@ jobs:
             docker tag "${LOCAL_IMAGE_TAG}" "${tag}"
             docker push "${tag}"
           done <<< "${TAGS}"
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - fetch-artifacts
+      - publish
+    if: needs.fetch-artifacts.outputs.publish_version_tags == 'true'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download source artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.SOURCE_ARTIFACT_NAME }}
+          path: ${{ runner.temp }}/artifacts
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.fetch-artifacts.outputs.version_tag }}
+          name: ${{ needs.fetch-artifacts.outputs.version_tag }}
+          generate_release_notes: true
+          make_latest: true
+          files: ${{ runner.temp }}/artifacts/repo-source.tar.gz

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Backend:
 - Entry point: `cd backend && python -m divevault.app`
 - HTTP server: Python `http.server` with threaded request handling
 - Storage: PostgreSQL via `psycopg`
-- Auth: Clerk session tokens, Clerk API keys, and short-lived desktop sync tokens
+- Auth: DiveVault first-party JWT sessions and short-lived desktop sync tokens
 
 Frontend:
 
@@ -142,11 +142,10 @@ See [`examples/kubernetes`](./examples/kubernetes) for a ready-to-use migration 
 Common variables from [`.env.example`](./.env.example):
 
 - `DATABASE_URL`: PostgreSQL connection string
-- `VITE_CLERK_PUBLISHABLE_KEY`: Clerk frontend key
-- `CLERK_SECRET_KEY`: Clerk backend secret for API key verification
-- `CLERK_FRONTEND_API_URL`: used to derive the Clerk issuer and JWKS URL
-- `CLERK_JWT_KEY` or `CLERK_JWKS_URL`: required for Clerk session token verification
-- `CLERK_AUTHORIZED_PARTIES`: allowed `azp` values
+- `AUTH_JWT_SECRET`: shared secret used to sign and verify DiveVault session tokens
+- `AUTH_JWT_ISSUER`: expected token issuer (defaults to `divevault.local`)
+- `AUTH_JWT_AUDIENCE`: expected token audience (defaults to `divevault.app`)
+- `AUTH_TOKEN_TTL_SECONDS`: session token lifetime in seconds (defaults to `43200`)
 - `CLI_AUTH_REQUEST_TTL` and `CLI_AUTH_TOKEN_TTL`: desktop sync token timing
 - `MAX_JSON_BODY_BYTES`: maximum accepted JSON request payload size (defaults to `1048576`)
 - `MAX_BACKUP_IMPORT_BYTES`: maximum accepted JSON payload size for `/api/backup/import` (defaults to `26214400`)
@@ -171,6 +170,22 @@ Run tests with:
 ```powershell
 .\.venv\Scripts\python.exe -m pytest -q backend/tests
 ```
+
+## Manual Clerk User Migration
+
+If you previously used Clerk, you can manually import users so existing per-user dive/profile records continue working with the same user IDs.
+
+1. Export your Clerk users to JSON and keep each `id` (for example `user_...`) plus `email`.
+2. Run:
+
+```powershell
+python backend/migrations/migrate_clerk_users_to_auth.py `
+  --database-url "$env:DATABASE_URL" `
+  --input ".\clerk-users.json" `
+  --default-password "ChangeMe123!"
+```
+
+3. Ask users to change their password after first login (or pre-seed per-user passwords in the JSON input via `password`).
 
 ## Image Versioning
 

--- a/README.md
+++ b/README.md
@@ -173,10 +173,9 @@ Run tests with:
 
 ## Manual Clerk User Migration
 
-If you previously used Clerk, you can manually import users so existing per-user dive/profile records continue working with the same user IDs.
+If you previously used Clerk, there are two migration paths.
 
-1. Export your Clerk users to JSON and keep each `id` (for example `user_...`) plus `email`.
-2. Run:
+Option 1 keeps each original Clerk `user_...` id and imports those same ids into `auth_users`. That is the safer path because existing dives, profiles, and device state continue to point at the same user ids.
 
 ```powershell
 python backend/migrations/migrate_clerk_users_to_auth.py `
@@ -185,16 +184,71 @@ python backend/migrations/migrate_clerk_users_to_auth.py `
   --default-password "ChangeMe123!"
 ```
 
-3. Ask users to change their password after first login (or pre-seed per-user passwords in the JSON input via `password`).
+Option 2 is for cases where you already created replacement internal users with different ids and now need to move all existing app-owned data from the old ids to those new ids.
+
+1. Create a JSON remap file, for example `user-id-remap.json`:
+
+```json
+[
+  {
+    "old_user_id": "user_old_clerk_id",
+    "new_user_id": "user_new_internal_id",
+    "email": "diver@example.com"
+  }
+]
+```
+
+2. Run a dry-run first. This validates that each target `new_user_id` already exists in `auth_users` and that it does not already own rows in the main per-user tables:
+
+```powershell
+python backend/migrations/remap_legacy_user_ids.py `
+  --database-url "$env:DATABASE_URL" `
+  --input ".\user-id-remap.json" `
+  --dry-run
+```
+
+3. Run the real remap once the preflight report is clean:
+
+```powershell
+python backend/migrations/remap_legacy_user_ids.py `
+  --database-url "$env:DATABASE_URL" `
+  --input ".\user-id-remap.json"
+```
+
+4. If you also want to remove any stale legacy auth rows after the data remap, rerun with:
+
+```powershell
+python backend/migrations/remap_legacy_user_ids.py `
+  --database-url "$env:DATABASE_URL" `
+  --input ".\user-id-remap.json" `
+  --delete-old-auth-users
+```
+
+The remap script updates user ownership in these tables:
+
+- `dives`
+- `device_state`
+- `user_profile`
+- `user_profile_license_documents`
+- `user_profile_licenses`
+- `user_profile_dive_sites`
+- `user_profile_buddies`
+- `user_profile_guides`
+- `cli_sync_auth_requests.user_id`
+- `auth_instance_settings.owner_user_id`
+- `auth_user_invites.invited_by_user_id`
+
+Do not use option 2 if the replacement `new_user_id` already has real dive/profile/device rows. The script intentionally aborts in that case to avoid merging two users into one by accident.
 
 ## Image Versioning
 
 Container publishing is driven by [`frontend/package.json`](./frontend/package.json).
 
 - On pushes to `master`, workflows publish image tags: `v<version>`, `stable`, and `latest`.
+- On pushes to `master`, workflows also create or update a GitHub release named `v<version>` and attach a packaged source tarball. GitHub's standard source archives remain available on the release page as well.
 - On non-`master` branches (or non-release contexts), workflows publish snapshot image tags in the format `v<version>-<short-sha>`, for example `v0.1.0-a1b2c3d`.
 
-This keeps `frontend/package.json` as the single image version source while publishing container images only.
+This keeps `frontend/package.json` as the single image version source while publishing both container images and the matching GitHub release from the same version value.
 
 ## libdivecomputer
 

--- a/backend/divevault/app.py
+++ b/backend/divevault/app.py
@@ -23,6 +23,9 @@ import secrets
 import signal
 import threading
 import time
+import hashlib
+import hmac
+import uuid
 from datetime import datetime, timezone
 from http.cookies import SimpleCookie
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -35,16 +38,21 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import jwt
 import psycopg
 from dotenv import load_dotenv
-from jwt import InvalidTokenError, PyJWKClient
+from jwt import InvalidTokenError
 
 from divevault.postgres_store import (
     CURRENT_SCHEMA_VERSION,
     approve_cli_sync_request,
     create_cli_sync_request,
+    create_auth_user,
+    create_password_reset_code,
+    delete_auth_user,
     delete_dive,
     get_device_state,
     get_db_schema_version,
     get_cli_sync_request_status,
+    get_auth_user_by_email,
+    get_auth_user_by_id,
     get_dive,
     get_dive_id_by_uid,
     get_public_profile_dives,
@@ -53,12 +61,17 @@ from divevault.postgres_store import (
     is_logbook_complete,
     insert_dive_record,
     list_all_dives,
+    list_auth_users,
     list_device_states,
     list_dives,
     open_db,
     save_user_profile,
     save_user_profile_license_pdf,
     save_device_state,
+    count_auth_users,
+    consume_password_reset_code,
+    update_auth_user,
+    update_auth_user_last_login,
     summarize_dives,
     update_dive_logbook,
     verify_cli_sync_token,
@@ -73,7 +86,7 @@ MAX_PROFILE_LICENSE_BYTES = 10 * 1024 * 1024
 load_dotenv(REPO_ROOT / ".env")
 
 
-class ClerkAuthError(Exception):
+class AuthError(Exception):
     def __init__(self, status: int, message: str) -> None:
         super().__init__(message)
         self.status = status
@@ -112,12 +125,6 @@ class FixedWindowRateLimiter:
             return True, max(expires_at - now_ts, 1)
 
 
-def normalize_pem_env(value: str | None) -> str | None:
-    if not value:
-        return None
-    return value.strip().replace("\\n", "\n")
-
-
 def normalize_bearer_token(value: str | None) -> str | None:
     if not value:
         return None
@@ -129,136 +136,58 @@ def normalize_bearer_token(value: str | None) -> str | None:
     return normalized or None
 
 
-class ClerkTokenVerifier:
+class DiveVaultAuthTokenVerifier:
     def __init__(
         self,
         *,
-        secret_key: str | None,
-        jwt_key: str | None,
-        jwks_url: str | None,
-        api_url: str | None,
-        issuer: str | None,
-        audience: str | None,
-        authorized_parties: set[str],
-        required_api_key_scopes: set[str],
+        jwt_secret: str,
+        jwt_issuer: str,
+        jwt_audience: str,
         sync_token_manager=None,
     ) -> None:
-        self.secret_key = secret_key.strip() if secret_key else None
-        self.jwt_key = normalize_pem_env(jwt_key)
-        self.jwks_url = jwks_url.strip() if jwks_url else None
-        self.api_url = (api_url or "https://api.clerk.com").rstrip("/")
-        self.issuer = issuer.rstrip("/") if issuer else None
-        self.audience = audience.strip() if audience else None
-        self.authorized_parties = authorized_parties
-        self.required_api_key_scopes = required_api_key_scopes
+        self.jwt_secret = jwt_secret
+        self.issuer = jwt_issuer
+        self.audience = jwt_audience
         self.sync_token_manager = sync_token_manager
-        self.jwks_client = PyJWKClient(self.jwks_url) if self.jwks_url and not self.jwt_key else None
 
     @property
     def configured(self) -> bool:
-        return bool(self.secret_key or self.jwt_key or self.jwks_client)
+        return bool(self.jwt_secret)
 
     def verify_request(self, headers) -> dict:
         token = normalize_bearer_token(self._extract_token(headers))
         if not token:
-            raise ClerkAuthError(401, "Missing Clerk bearer token")
+            raise AuthError(401, "Missing authentication bearer token")
 
         if token.startswith("dvsync_"):
             return self._verify_sync_token(token)
-        if token.startswith("ak_"):
-            return self._verify_api_key(token)
-        if token.startswith("sk_"):
-            raise ClerkAuthError(401, "Received CLERK_SECRET_KEY instead of a Clerk API key secret. Use a user or organization API key that starts with ak_.")
-        if token.startswith("pk_"):
-            raise ClerkAuthError(401, "Received Clerk publishable key instead of an API credential. Use a Clerk API key secret that starts with ak_.")
-
         return self._verify_session_token(token)
 
     def _verify_session_token(self, token: str) -> dict:
-        if not self.jwt_key and not self.jwks_client:
-            raise ClerkAuthError(503, "Clerk session token verification is not configured on the backend")
-
-        signing_key = self.jwt_key
-        if not signing_key and self.jwks_client:
-            try:
-                signing_key = self.jwks_client.get_signing_key_from_jwt(token).key
-            except Exception as exc:  # pragma: no cover - network/JWKS failures are runtime-dependent
-                raise ClerkAuthError(503, f"Unable to resolve Clerk signing key: {exc}") from exc
-
-        if not signing_key:
-            raise ClerkAuthError(503, "Clerk authentication is not configured on the backend")
-
-        decode_kwargs = {
-            "algorithms": ["RS256"],
-            "issuer": self.issuer,
-            "options": {
-                "verify_aud": bool(self.audience),
-                "verify_iss": bool(self.issuer),
-            },
-            "leeway": 5,
-        }
-        if self.audience:
-            decode_kwargs["audience"] = self.audience
-
         try:
-            claims = jwt.decode(token, signing_key, **decode_kwargs)
+            claims = jwt.decode(
+                token,
+                self.jwt_secret,
+                algorithms=["HS256"],
+                issuer=self.issuer,
+                audience=self.audience,
+                options={"verify_exp": True},
+                leeway=5,
+            )
         except InvalidTokenError as exc:
-            raise ClerkAuthError(401, f"Invalid Clerk session token: {exc}") from exc
-
-        if self.authorized_parties:
-            authorized_party = claims.get("azp")
-            if authorized_party not in self.authorized_parties:
-                raise ClerkAuthError(401, "Clerk session token origin is not allowed")
+            raise AuthError(401, f"Invalid session token: {exc}") from exc
 
         claims.setdefault("token_type", "session_token")
         return claims
 
     def _verify_sync_token(self, token: str) -> dict:
         if self.sync_token_manager is None:
-            raise ClerkAuthError(503, "Desktop sync login is not configured on the backend")
+            raise AuthError(503, "Desktop sync login is not configured on the backend")
 
         claims = self.sync_token_manager.verify_token(token)
         if claims is None:
-            raise ClerkAuthError(401, "Desktop sync token is invalid or expired")
+            raise AuthError(401, "Desktop sync token is invalid or expired")
         return claims
-
-    def _verify_api_key(self, token: str) -> dict:
-        if not self.secret_key:
-            raise ClerkAuthError(503, "Clerk API key verification requires CLERK_SECRET_KEY on the backend")
-
-        req = urlrequest.Request(
-            f"{self.api_url}/v1/api_keys/verify",
-            data=json.dumps({"secret": token}).encode("utf-8"),
-            headers={
-                "Authorization": f"Bearer {self.secret_key}",
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            },
-            method="POST",
-        )
-
-        try:
-            with urlrequest.urlopen(req, timeout=15) as response:
-                payload = json.loads(response.read().decode("utf-8"))
-        except urlerror.HTTPError as exc:
-            details = exc.read().decode("utf-8", errors="replace")
-            if exc.code == 403 and ("Cloudflare" in details or "Error 1010" in details or "Access denied" in details):
-                raise ClerkAuthError(
-                    503,
-                    "Clerk API key verification is blocked by Cloudflare from this network. The backend cannot validate API keys from the current IP.",
-                ) from exc
-            if exc.code >= 500:
-                raise ClerkAuthError(503, f"Clerk API key verification failed: {details}") from exc
-            raise ClerkAuthError(401, "Invalid Clerk API key") from exc
-        except (urlerror.URLError, TimeoutError, json.JSONDecodeError) as exc:
-            raise ClerkAuthError(503, f"Unable to verify Clerk API key: {exc}") from exc
-
-        api_key_scopes = set(payload.get("scopes") or [])
-        if self.required_api_key_scopes and not self.required_api_key_scopes.issubset(api_key_scopes):
-            raise ClerkAuthError(403, "Clerk API key is missing required scopes")
-
-        payload.setdefault("token_type", "api_key")
-        return payload
 
     @staticmethod
     def _extract_token(headers) -> str | None:
@@ -274,12 +203,6 @@ class ClerkTokenVerifier:
         cookie.load(cookie_header)
         session_cookie = cookie.get("__session")
         return session_cookie.value if session_cookie else None
-
-
-def parse_csv_env(value: str | None) -> set[str]:
-    if not value:
-        return set()
-    return {item.strip() for item in value.split(",") if item.strip()}
 
 
 def sanitize_profile_license_filename(value: object) -> str:
@@ -558,28 +481,47 @@ class CliSyncTokenManager:
             return dict(claims)
 
 
-def build_clerk_verifier(args: argparse.Namespace, *, sync_token_manager: CliSyncTokenManager | None) -> ClerkTokenVerifier | None:
-    frontend_api_url = args.clerk_frontend_api_url.rstrip("/") if args.clerk_frontend_api_url else None
-    jwks_url = args.clerk_jwks_url or (f"{frontend_api_url}/.well-known/jwks.json" if frontend_api_url else None)
-    issuer = args.clerk_issuer or frontend_api_url
-    verifier = ClerkTokenVerifier(
-        secret_key=args.clerk_secret_key,
-        jwt_key=args.clerk_jwt_key,
-        jwks_url=jwks_url,
-        api_url=args.clerk_api_url,
-        issuer=issuer,
-        audience=args.clerk_audience,
-        authorized_parties=parse_csv_env(args.clerk_authorized_parties),
-        required_api_key_scopes=parse_csv_env(args.clerk_api_key_scopes),
+def hash_password(password: str, *, salt_hex: str | None = None) -> str:
+    salt = bytes.fromhex(salt_hex) if salt_hex else secrets.token_bytes(16)
+    digest = hashlib.scrypt(password.encode("utf-8"), salt=salt, n=2**14, r=8, p=1, dklen=64)
+    return f"scrypt${salt.hex()}${digest.hex()}"
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    if not isinstance(password_hash, str) or not password_hash.startswith("scrypt$"):
+        return False
+    parts = password_hash.split("$")
+    if len(parts) != 3:
+        return False
+    _, salt_hex, expected_hex = parts
+    actual_hash = hash_password(password, salt_hex=salt_hex)
+    return hmac.compare_digest(actual_hash, password_hash)
+
+
+def issue_session_token(*, user_id: str, email: str, role: str, jwt_secret: str, issuer: str, audience: str, ttl_seconds: int) -> str:
+    now_timestamp = int(time.time())
+    payload = {
+        "sub": user_id,
+        "sid": f"session_{uuid.uuid4().hex}",
+        "email": email,
+        "role": role,
+        "token_type": "session_token",
+        "iat": now_timestamp,
+        "nbf": now_timestamp,
+        "exp": now_timestamp + max(ttl_seconds, 300),
+        "iss": issuer,
+        "aud": audience,
+    }
+    return jwt.encode(payload, jwt_secret, algorithm="HS256")
+
+
+def build_auth_verifier(args: argparse.Namespace, *, sync_token_manager: CliSyncTokenManager | None) -> DiveVaultAuthTokenVerifier:
+    return DiveVaultAuthTokenVerifier(
+        jwt_secret=args.auth_jwt_secret,
+        jwt_issuer=args.auth_jwt_issuer,
+        jwt_audience=args.auth_jwt_audience,
         sync_token_manager=sync_token_manager,
     )
-    if verifier.configured:
-        return verifier
-
-    LOGGER.warning(
-        "Clerk authentication is not configured. Set CLERK_SECRET_KEY for API keys and CLERK_JWT_KEY or CLERK_JWKS_URL (or CLERK_FRONTEND_API_URL) for session tokens."
-    )
-    return None
 
 
 def resolve_repo_path(path_value: str | Path) -> Path:
@@ -1473,16 +1415,43 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
             claims = self._require_auth()
             if claims is None:
                 return
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                auth_user = get_auth_user_by_id(conn, claims.get("sub") or "")
+            finally:
+                conn.close()
             self._send_json(
                 200,
                 {
                     "token_type": claims.get("token_type", "session_token"),
                     "session_id": claims.get("sid"),
                     "user_id": claims.get("sub"),
-                    "subject": claims.get("subject"),
-                    "scopes": claims.get("scopes"),
+                    "email": (auth_user or {}).get("email") or claims.get("email"),
+                    "first_name": (auth_user or {}).get("first_name", ""),
+                    "last_name": (auth_user or {}).get("last_name", ""),
+                    "role": (auth_user or {}).get("role") or claims.get("role", "user"),
+                    "is_active": bool((auth_user or {}).get("is_active", True)),
                 },
             )
+            return
+
+        if path == "/api/users":
+            claims = self._require_auth()
+            if claims is None:
+                return
+            if not self._is_admin_claims(claims):
+                self._send_json(403, {"error": "Admin role required"})
+                return
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                users = list_auth_users(conn)
+            finally:
+                conn.close()
+            self._send_json(200, {"users": users})
             return
 
         if path == "/api/cli-auth/request":
@@ -1582,11 +1551,166 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:
         LOGGER.info("POST %s", self.path)
+        if self.path == "/api/auth/register":
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            email = str(payload.get("email") or "").strip().lower()
+            password = str(payload.get("password") or "")
+            if not email or "@" not in email:
+                self._send_json(400, {"error": "Valid email is required"})
+                return
+            if len(password) < 8:
+                self._send_json(400, {"error": "Password must be at least 8 characters"})
+                return
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                if get_auth_user_by_email(conn, email):
+                    self._send_json(409, {"error": "Email already registered"})
+                    return
+                user_count = count_auth_users(conn)
+                role = "admin" if user_count == 0 else "user"
+                user = create_auth_user(
+                    conn,
+                    user_id=f"user_{uuid.uuid4().hex}",
+                    email=email,
+                    password_hash=hash_password(password),
+                    first_name=str(payload.get("first_name") or "").strip(),
+                    last_name=str(payload.get("last_name") or "").strip(),
+                    role=role,
+                )
+            finally:
+                conn.close()
+            self._send_json(201, {"user_id": user.get("id"), "email": user.get("email"), "role": user.get("role")})
+            return
+
+        if self.path == "/api/auth/login":
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            email = str(payload.get("email") or "").strip().lower()
+            password = str(payload.get("password") or "")
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                user = get_auth_user_by_email(conn, email)
+                if not user or not verify_password(password, user.get("password_hash") or ""):
+                    self._send_json(401, {"error": "Invalid email or password"})
+                    return
+                if not bool(user.get("is_active", True)):
+                    self._send_json(403, {"error": "User account is inactive"})
+                    return
+                update_auth_user_last_login(conn, user.get("id"))
+            finally:
+                conn.close()
+            token = issue_session_token(
+                user_id=user.get("id"),
+                email=user.get("email"),
+                role=user.get("role") or "user",
+                jwt_secret=self.server.auth_jwt_secret,
+                issuer=self.server.auth_jwt_issuer,
+                audience=self.server.auth_jwt_audience,
+                ttl_seconds=self.server.auth_token_ttl_seconds,
+            )
+            self._send_json(200, {"token": token})
+            return
+
+        if self.path == "/api/auth/recover/start":
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            email = str(payload.get("email") or "").strip().lower()
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                user = get_auth_user_by_email(conn, email)
+                if user:
+                    code = f"{secrets.randbelow(1000000):06d}"
+                    now_timestamp = int(time.time())
+                    create_password_reset_code(
+                        conn,
+                        email=email,
+                        code=code,
+                        expires_at=now_timestamp + 15 * 60,
+                        now_timestamp=now_timestamp,
+                    )
+                else:
+                    code = "000000"
+            finally:
+                conn.close()
+            self._send_json(200, {"message": "If the account exists, a reset code was generated.", "recovery_code": code})
+            return
+
+        if self.path == "/api/auth/recover/complete":
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            email = str(payload.get("email") or "").strip().lower()
+            code = str(payload.get("code") or "").strip()
+            new_password = str(payload.get("password") or "")
+            if len(new_password) < 8:
+                self._send_json(400, {"error": "Password must be at least 8 characters"})
+                return
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                valid_code = consume_password_reset_code(conn, email=email, code=code, now_timestamp=int(time.time()))
+                user = get_auth_user_by_email(conn, email)
+                if not valid_code or not user:
+                    self._send_json(400, {"error": "Invalid or expired recovery code"})
+                    return
+                update_auth_user(conn, user.get("id"), {"password_hash": hash_password(new_password)})
+            finally:
+                conn.close()
+            self._send_json(200, {"reset": True})
+            return
+
         if self.path == "/api/cli-auth/request":
             if not self._enforce_rate_limit("cli_auth_request_create"):
                 return
             payload = self.server.cli_auth_manager.create_request()
             self._send_json(201, payload)
+            return
+
+        if self.path == "/api/users":
+            claims = self._require_auth()
+            if claims is None:
+                return
+            if not self._is_admin_claims(claims):
+                self._send_json(403, {"error": "Admin role required"})
+                return
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            email = str(payload.get("email") or "").strip().lower()
+            password = str(payload.get("password") or "")
+            if not email or not password:
+                self._send_json(400, {"error": "email and password are required"})
+                return
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                if get_auth_user_by_email(conn, email):
+                    self._send_json(409, {"error": "Email already registered"})
+                    return
+                created = create_auth_user(
+                    conn,
+                    user_id=f"user_{uuid.uuid4().hex}",
+                    email=email,
+                    password_hash=hash_password(password),
+                    first_name=str(payload.get("first_name") or "").strip(),
+                    last_name=str(payload.get("last_name") or "").strip(),
+                    role=str(payload.get("role") or "user").strip().lower() or "user",
+                )
+            finally:
+                conn.close()
+            self._send_json(201, {"user": created})
             return
 
         if self.path == "/api/backup/import":
@@ -1698,6 +1822,57 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
 
     def do_PUT(self) -> None:
         LOGGER.info("PUT %s", self.path)
+        if self.path == "/api/auth/password":
+            claims = self._require_auth()
+            if claims is None:
+                return
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            current_password = str(payload.get("current_password") or "")
+            new_password = str(payload.get("new_password") or "")
+            if len(new_password) < 8:
+                self._send_json(400, {"error": "New password must be at least 8 characters"})
+                return
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                user = get_auth_user_by_id(conn, claims.get("sub") or "")
+                if not user or not verify_password(current_password, user.get("password_hash") or ""):
+                    self._send_json(401, {"error": "Current password is incorrect"})
+                    return
+                update_auth_user(conn, user.get("id"), {"password_hash": hash_password(new_password)})
+            finally:
+                conn.close()
+            self._send_json(200, {"updated": True})
+            return
+
+        match = re.fullmatch(r"/api/users/(user_[A-Za-z0-9]+)", self.path)
+        if match:
+            claims = self._require_auth()
+            if claims is None:
+                return
+            if not self._is_admin_claims(claims):
+                self._send_json(403, {"error": "Admin role required"})
+                return
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            user_id = match.group(1)
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                updated = update_auth_user(conn, user_id, payload)
+            finally:
+                conn.close()
+            if not updated:
+                self._send_json(404, {"error": "User not found"})
+                return
+            self._send_json(200, {"user": updated})
+            return
+
         if self.path == "/api/profile":
             user_id = self._require_principal_id()
             if user_id is None:
@@ -1839,6 +2014,28 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
 
     def do_DELETE(self) -> None:
         LOGGER.info("DELETE %s", self.path)
+        match = re.fullmatch(r"/api/users/(user_[A-Za-z0-9]+)", self.path)
+        if match:
+            claims = self._require_auth()
+            if claims is None:
+                return
+            if not self._is_admin_claims(claims):
+                self._send_json(403, {"error": "Admin role required"})
+                return
+            target_user_id = match.group(1)
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                deleted = delete_auth_user(conn, target_user_id)
+            finally:
+                conn.close()
+            if not deleted:
+                self._send_json(404, {"error": "User not found"})
+                return
+            self._send_json(200, {"deleted": True, "user_id": target_user_id})
+            return
+
         match = re.fullmatch(r"/api/dives/(\d+)", self.path)
         if not match:
             self._send_json(404, {"error": "Not found"})
@@ -1877,16 +2074,20 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
             return None
 
     def _require_auth(self) -> dict | None:
-        verifier = getattr(self.server, "clerk_verifier", None)
+        verifier = getattr(self.server, "auth_verifier", None)
         if verifier is None:
-            self._send_json(503, {"error": "Clerk authentication is not configured on the backend"})
+            self._send_json(503, {"error": "Authentication is not configured on the backend"})
             return None
 
         try:
             return verifier.verify_request(self.headers)
-        except ClerkAuthError as exc:
+        except AuthError as exc:
             self._send_json(exc.status, {"error": exc.message})
             return None
+
+    @staticmethod
+    def _is_admin_claims(claims: dict | None) -> bool:
+        return bool(isinstance(claims, dict) and str(claims.get("role") or "").lower() == "admin")
 
     def _require_browser_session_auth(self) -> dict | None:
         claims = self._require_auth()
@@ -1999,7 +2200,7 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
     def _send_config_js(self) -> None:
         body = (
             "window.__APP_CONFIG__ = "
-            + json.dumps({"clerkPublishableKey": self.server.clerk_publishable_key})
+            + json.dumps({"authEnabled": True})
             + ";\n"
         ).encode("utf-8")
         self.send_response(200)
@@ -2063,16 +2264,10 @@ def main() -> None:
         default=os.getenv("FRONTEND_DIR", "frontend/dist"),
         help="Path to static frontend assets, resolved relative to the repository root when not absolute",
     )
-    parser.add_argument("--clerk-publishable-key", default=os.getenv("VITE_CLERK_PUBLISHABLE_KEY"), help="Clerk publishable key exposed to the frontend at runtime")
-    parser.add_argument("--clerk-secret-key", default=os.getenv("CLERK_SECRET_KEY"), help="Clerk secret key, required to verify Clerk API keys")
-    parser.add_argument("--clerk-api-url", default=os.getenv("CLERK_API_URL", "https://api.clerk.com"), help="Clerk Backend API base URL")
-    parser.add_argument("--clerk-jwt-key", default=os.getenv("CLERK_JWT_KEY"), help="Clerk JWT public key in PEM format")
-    parser.add_argument("--clerk-jwks-url", default=os.getenv("CLERK_JWKS_URL"), help="Clerk JWKS URL")
-    parser.add_argument("--clerk-frontend-api-url", default=os.getenv("CLERK_FRONTEND_API_URL"), help="Clerk frontend API URL, used to derive the JWKS URL and issuer")
-    parser.add_argument("--clerk-issuer", default=os.getenv("CLERK_ISSUER"), help="Expected Clerk token issuer")
-    parser.add_argument("--clerk-audience", default=os.getenv("CLERK_AUDIENCE"), help="Expected Clerk token audience")
-    parser.add_argument("--clerk-authorized-parties", default=os.getenv("CLERK_AUTHORIZED_PARTIES"), help="Comma-separated allowed values for the Clerk azp claim")
-    parser.add_argument("--clerk-api-key-scopes", default=os.getenv("CLERK_API_KEY_SCOPES"), help="Comma-separated Clerk API key scopes required for backend access")
+    parser.add_argument("--auth-jwt-secret", default=os.getenv("AUTH_JWT_SECRET", "dev-only-change-me"), help="Shared secret used to sign and verify first-party DiveVault session tokens")
+    parser.add_argument("--auth-jwt-issuer", default=os.getenv("AUTH_JWT_ISSUER", "divevault.local"), help="JWT issuer for first-party DiveVault tokens")
+    parser.add_argument("--auth-jwt-audience", default=os.getenv("AUTH_JWT_AUDIENCE", "divevault.app"), help="JWT audience for first-party DiveVault tokens")
+    parser.add_argument("--auth-token-ttl-seconds", type=int, default=int(os.getenv("AUTH_TOKEN_TTL_SECONDS", "43200")), help="Session token TTL in seconds")
     parser.add_argument("--cli-auth-request-ttl", type=int, default=int(os.getenv("CLI_AUTH_REQUEST_TTL", "600")), help="Seconds a desktop login request stays valid")
     parser.add_argument("--cli-auth-token-ttl", type=int, default=int(os.getenv("CLI_AUTH_TOKEN_TTL", "1800")), help="Seconds an approved desktop sync token stays valid")
     parser.add_argument("--nominatim-base-url", default=os.getenv("NOMINATIM_BASE_URL", "https://nominatim.openstreetmap.org"), help="Base URL for the Nominatim search service")
@@ -2138,8 +2333,11 @@ def main() -> None:
         token_ttl_seconds=args.cli_auth_token_ttl,
         database_url=args.database_url,
     )
-    server.clerk_verifier = build_clerk_verifier(args, sync_token_manager=server.cli_auth_manager)
-    server.clerk_publishable_key = args.clerk_publishable_key
+    server.auth_verifier = build_auth_verifier(args, sync_token_manager=server.cli_auth_manager)
+    server.auth_jwt_secret = args.auth_jwt_secret
+    server.auth_jwt_issuer = args.auth_jwt_issuer
+    server.auth_jwt_audience = args.auth_jwt_audience
+    server.auth_token_ttl_seconds = max(args.auth_token_ttl_seconds, 300)
     server.cors_origin = args.cors_origin
     server.max_json_body_bytes = max(args.max_json_body_bytes, 1)
     server.max_backup_import_bytes = max(args.max_backup_import_bytes, 1)

--- a/backend/divevault/app.py
+++ b/backend/divevault/app.py
@@ -43,11 +43,15 @@ from jwt import InvalidTokenError
 from divevault.postgres_store import (
     CURRENT_SCHEMA_VERSION,
     approve_cli_sync_request,
+    create_auth_invite,
     create_cli_sync_request,
     create_auth_user,
-    create_password_reset_code,
+    create_auth_user_from_invite,
+    create_bootstrap_auth_user,
     delete_auth_user,
     delete_dive,
+    get_auth_instance_settings,
+    get_auth_invite_by_token,
     get_device_state,
     get_db_schema_version,
     get_cli_sync_request_status,
@@ -69,7 +73,7 @@ from divevault.postgres_store import (
     save_user_profile_license_pdf,
     save_device_state,
     count_auth_users,
-    consume_password_reset_code,
+    update_auth_instance_settings,
     update_auth_user,
     update_auth_user_last_login,
     summarize_dives,
@@ -1411,6 +1415,31 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
             )
             return
 
+        if path == "/api/auth/status":
+            invite_token = (self._single_query_arg(query, "invite_token") or "").strip()
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                settings = get_auth_instance_settings(conn)
+                invite = None
+                if invite_token:
+                    invite = get_auth_invite_by_token(conn, invite_token, now_timestamp=int(time.time()))
+            finally:
+                conn.close()
+            self._send_json(
+                200,
+                {
+                    "initialized": settings.get("initialized", False),
+                    "user_count": settings.get("user_count", 0),
+                    "bootstrap_registration_open": settings.get("bootstrap_registration_open", False),
+                    "public_registration_enabled": settings.get("public_registration_enabled", False),
+                    "public_registration_open": settings.get("public_registration_open", False),
+                    "invite": invite,
+                },
+            )
+            return
+
         if path == "/api/auth/me":
             claims = self._require_auth()
             if claims is None:
@@ -1420,6 +1449,7 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
                 return
             try:
                 auth_user = get_auth_user_by_id(conn, claims.get("sub") or "")
+                auth_settings = get_auth_instance_settings(conn)
             finally:
                 conn.close()
             self._send_json(
@@ -1433,16 +1463,28 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
                     "last_name": (auth_user or {}).get("last_name", ""),
                     "role": (auth_user or {}).get("role") or claims.get("role", "user"),
                     "is_active": bool((auth_user or {}).get("is_active", True)),
+                    "is_owner": self._principal_id_from_claims(claims) == auth_settings.get("owner_user_id"),
                 },
             )
             return
 
-        if path == "/api/users":
-            claims = self._require_auth()
+        if path == "/api/auth/settings":
+            claims = self._require_owner_auth()
             if claims is None:
                 return
-            if not self._is_admin_claims(claims):
-                self._send_json(403, {"error": "Admin role required"})
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                settings = get_auth_instance_settings(conn)
+            finally:
+                conn.close()
+            self._send_json(200, settings)
+            return
+
+        if path == "/api/users":
+            claims = self._require_owner_auth()
+            if claims is None:
                 return
             conn = self._open_db()
             if conn is None:
@@ -1557,7 +1599,8 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
                 return
             email = str(payload.get("email") or "").strip().lower()
             password = str(payload.get("password") or "")
-            if not email or "@" not in email:
+            invite_token = str(payload.get("invite_token") or "").strip()
+            if not invite_token and (not email or "@" not in email):
                 self._send_json(400, {"error": "Valid email is required"})
                 return
             if len(password) < 8:
@@ -1567,23 +1610,75 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
             if conn is None:
                 return
             try:
-                if get_auth_user_by_email(conn, email):
-                    self._send_json(409, {"error": "Email already registered"})
-                    return
-                user_count = count_auth_users(conn)
-                role = "admin" if user_count == 0 else "user"
-                user = create_auth_user(
-                    conn,
-                    user_id=f"user_{uuid.uuid4().hex}",
-                    email=email,
-                    password_hash=hash_password(password),
-                    first_name=str(payload.get("first_name") or "").strip(),
-                    last_name=str(payload.get("last_name") or "").strip(),
-                    role=role,
-                )
+                if invite_token:
+                    invite = get_auth_invite_by_token(conn, invite_token, now_timestamp=int(time.time()))
+                    if not invite:
+                        self._send_json(400, {"error": "Invitation is invalid or expired"})
+                        return
+                    invite_email = str(invite.get("email") or "").strip().lower()
+                    if email and email != invite_email:
+                        self._send_json(400, {"error": "Invitation email does not match the submitted email"})
+                        return
+                    try:
+                        user = create_auth_user_from_invite(
+                            conn,
+                            invite_token=invite_token,
+                            user_id=f"user_{uuid.uuid4().hex}",
+                            password_hash=hash_password(password),
+                        )
+                    except ValueError as exc:
+                        message = str(exc)
+                        if message == "Email already registered":
+                            self._send_json(409, {"error": message})
+                            return
+                        self._send_json(400, {"error": message})
+                        return
+                else:
+                    settings = get_auth_instance_settings(conn)
+                    if get_auth_user_by_email(conn, email):
+                        self._send_json(409, {"error": "Email already registered"})
+                        return
+                    if settings.get("bootstrap_registration_open"):
+                        try:
+                            user = create_bootstrap_auth_user(
+                                conn,
+                                user_id=f"user_{uuid.uuid4().hex}",
+                                email=email,
+                                password_hash=hash_password(password),
+                                first_name=str(payload.get("first_name") or "").strip(),
+                                last_name=str(payload.get("last_name") or "").strip(),
+                            )
+                        except ValueError as exc:
+                            message = str(exc)
+                            if message == "Email already registered":
+                                self._send_json(409, {"error": message})
+                                return
+                            self._send_json(403, {"error": message})
+                            return
+                    elif settings.get("public_registration_enabled"):
+                        user = create_auth_user(
+                            conn,
+                            user_id=f"user_{uuid.uuid4().hex}",
+                            email=email,
+                            password_hash=hash_password(password),
+                            first_name=str(payload.get("first_name") or "").strip(),
+                            last_name=str(payload.get("last_name") or "").strip(),
+                            role="user",
+                        )
+                    else:
+                        self._send_json(403, {"error": "Public registration is closed"})
+                        return
             finally:
                 conn.close()
-            self._send_json(201, {"user_id": user.get("id"), "email": user.get("email"), "role": user.get("role")})
+            self._send_json(
+                201,
+                {
+                    "user_id": user.get("id"),
+                    "email": user.get("email"),
+                    "role": user.get("role"),
+                    "is_owner": bool(invite_token) is False and user.get("role") == "admin",
+                },
+            )
             return
 
         if self.path == "/api/auth/login":
@@ -1618,58 +1713,6 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
             self._send_json(200, {"token": token})
             return
 
-        if self.path == "/api/auth/recover/start":
-            payload = self._read_json_body()
-            if payload is None:
-                return
-            email = str(payload.get("email") or "").strip().lower()
-            conn = self._open_db()
-            if conn is None:
-                return
-            try:
-                user = get_auth_user_by_email(conn, email)
-                if user:
-                    code = f"{secrets.randbelow(1000000):06d}"
-                    now_timestamp = int(time.time())
-                    create_password_reset_code(
-                        conn,
-                        email=email,
-                        code=code,
-                        expires_at=now_timestamp + 15 * 60,
-                        now_timestamp=now_timestamp,
-                    )
-                else:
-                    code = "000000"
-            finally:
-                conn.close()
-            self._send_json(200, {"message": "If the account exists, a reset code was generated.", "recovery_code": code})
-            return
-
-        if self.path == "/api/auth/recover/complete":
-            payload = self._read_json_body()
-            if payload is None:
-                return
-            email = str(payload.get("email") or "").strip().lower()
-            code = str(payload.get("code") or "").strip()
-            new_password = str(payload.get("password") or "")
-            if len(new_password) < 8:
-                self._send_json(400, {"error": "Password must be at least 8 characters"})
-                return
-            conn = self._open_db()
-            if conn is None:
-                return
-            try:
-                valid_code = consume_password_reset_code(conn, email=email, code=code, now_timestamp=int(time.time()))
-                user = get_auth_user_by_email(conn, email)
-                if not valid_code or not user:
-                    self._send_json(400, {"error": "Invalid or expired recovery code"})
-                    return
-                update_auth_user(conn, user.get("id"), {"password_hash": hash_password(new_password)})
-            finally:
-                conn.close()
-            self._send_json(200, {"reset": True})
-            return
-
         if self.path == "/api/cli-auth/request":
             if not self._enforce_rate_limit("cli_auth_request_create"):
                 return
@@ -1677,12 +1720,58 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
             self._send_json(201, payload)
             return
 
-        if self.path == "/api/users":
-            claims = self._require_auth()
+        if self.path == "/api/auth/invitations":
+            claims = self._require_owner_auth()
             if claims is None:
                 return
-            if not self._is_admin_claims(claims):
-                self._send_json(403, {"error": "Admin role required"})
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            email = str(payload.get("email") or "").strip().lower()
+            if not email or "@" not in email:
+                self._send_json(400, {"error": "Valid email is required"})
+                return
+            role = self._normalize_user_role(payload.get("role"))
+            if role is None:
+                self._send_json(400, {"error": "Role must be either 'user' or 'admin'"})
+                return
+            expires_in_days = self._parse_int(str(payload.get("expires_in_days") or "7"), default=7, max_value=30)
+            now_timestamp = int(time.time())
+            expires_at = now_timestamp + max(expires_in_days, 1) * 24 * 60 * 60
+            invite_token = secrets.token_urlsafe(24)
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                if get_auth_user_by_email(conn, email):
+                    self._send_json(409, {"error": "Email already registered"})
+                    return
+                invite = create_auth_invite(
+                    conn,
+                    token=invite_token,
+                    email=email,
+                    first_name=str(payload.get("first_name") or "").strip(),
+                    last_name=str(payload.get("last_name") or "").strip(),
+                    role=role,
+                    invited_by_user_id=self._principal_id_from_claims(claims) or "",
+                    expires_at=expires_at,
+                    now_timestamp=now_timestamp,
+                )
+            finally:
+                conn.close()
+            invite_query = urlencode({"invite_token": invite_token})
+            self._send_json(
+                201,
+                {
+                    "invite": invite,
+                    "invite_url": f"/?{invite_query}",
+                },
+            )
+            return
+
+        if self.path == "/api/users":
+            claims = self._require_owner_auth()
+            if claims is None:
                 return
             payload = self._read_json_body()
             if payload is None:
@@ -1691,6 +1780,10 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
             password = str(payload.get("password") or "")
             if not email or not password:
                 self._send_json(400, {"error": "email and password are required"})
+                return
+            role = self._normalize_user_role(payload.get("role"))
+            if role is None:
+                self._send_json(400, {"error": "Role must be either 'user' or 'admin'"})
                 return
             conn = self._open_db()
             if conn is None:
@@ -1706,7 +1799,7 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
                     password_hash=hash_password(password),
                     first_name=str(payload.get("first_name") or "").strip(),
                     last_name=str(payload.get("last_name") or "").strip(),
-                    role=str(payload.get("role") or "user").strip().lower() or "user",
+                    role=role,
                 )
             finally:
                 conn.close()
@@ -1822,6 +1915,29 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
 
     def do_PUT(self) -> None:
         LOGGER.info("PUT %s", self.path)
+        if self.path == "/api/auth/settings":
+            claims = self._require_owner_auth()
+            if claims is None:
+                return
+            payload = self._read_json_body()
+            if payload is None:
+                return
+            if "public_registration_enabled" not in payload:
+                self._send_json(400, {"error": "public_registration_enabled is required"})
+                return
+            conn = self._open_db()
+            if conn is None:
+                return
+            try:
+                settings = update_auth_instance_settings(
+                    conn,
+                    public_registration_enabled=bool(payload.get("public_registration_enabled")),
+                )
+            finally:
+                conn.close()
+            self._send_json(200, settings)
+            return
+
         if self.path == "/api/auth/password":
             claims = self._require_auth()
             if claims is None:
@@ -1850,20 +1966,32 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
 
         match = re.fullmatch(r"/api/users/(user_[A-Za-z0-9]+)", self.path)
         if match:
-            claims = self._require_auth()
+            claims = self._require_owner_auth()
             if claims is None:
-                return
-            if not self._is_admin_claims(claims):
-                self._send_json(403, {"error": "Admin role required"})
                 return
             payload = self._read_json_body()
             if payload is None:
                 return
             user_id = match.group(1)
+            if "role" in payload:
+                role = self._normalize_user_role(payload.get("role"))
+                if role is None:
+                    self._send_json(400, {"error": "Role must be either 'user' or 'admin'"})
+                    return
+                payload = dict(payload)
+                payload["role"] = role
             conn = self._open_db()
             if conn is None:
                 return
             try:
+                settings = get_auth_instance_settings(conn)
+                if user_id == settings.get("owner_user_id"):
+                    if "is_active" in payload and not bool(payload.get("is_active")):
+                        self._send_json(400, {"error": "The instance owner cannot be deactivated"})
+                        return
+                    if payload.get("role") == "user":
+                        self._send_json(400, {"error": "The instance owner must retain the admin role"})
+                        return
                 updated = update_auth_user(conn, user_id, payload)
             finally:
                 conn.close()
@@ -2016,17 +2144,18 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
         LOGGER.info("DELETE %s", self.path)
         match = re.fullmatch(r"/api/users/(user_[A-Za-z0-9]+)", self.path)
         if match:
-            claims = self._require_auth()
+            claims = self._require_owner_auth()
             if claims is None:
-                return
-            if not self._is_admin_claims(claims):
-                self._send_json(403, {"error": "Admin role required"})
                 return
             target_user_id = match.group(1)
             conn = self._open_db()
             if conn is None:
                 return
             try:
+                settings = get_auth_instance_settings(conn)
+                if target_user_id == settings.get("owner_user_id"):
+                    self._send_json(400, {"error": "The instance owner cannot be deleted"})
+                    return
                 deleted = delete_auth_user(conn, target_user_id)
             finally:
                 conn.close()
@@ -2088,6 +2217,33 @@ class DiveBackendHandler(BaseHTTPRequestHandler):
     @staticmethod
     def _is_admin_claims(claims: dict | None) -> bool:
         return bool(isinstance(claims, dict) and str(claims.get("role") or "").lower() == "admin")
+
+    def _require_owner_auth(self) -> dict | None:
+        claims = self._require_auth()
+        if claims is None:
+            return None
+        principal_id = self._principal_id_from_claims(claims)
+        if not principal_id:
+            self._send_json(403, {"error": "Authenticated identity is missing a stable user identifier"})
+            return None
+        conn = self._open_db()
+        if conn is None:
+            return None
+        try:
+            settings = get_auth_instance_settings(conn)
+        finally:
+            conn.close()
+        if principal_id != settings.get("owner_user_id"):
+            self._send_json(403, {"error": "Instance owner required"})
+            return None
+        return claims
+
+    @staticmethod
+    def _normalize_user_role(value: object) -> str | None:
+        normalized = str(value or "user").strip().lower()
+        if normalized not in {"user", "admin"}:
+            return None
+        return normalized
 
     def _require_browser_session_auth(self) -> dict | None:
         claims = self._require_auth()

--- a/backend/divevault/postgres_store.py
+++ b/backend/divevault/postgres_store.py
@@ -110,12 +110,34 @@ CREATE TABLE IF NOT EXISTS cli_sync_auth_requests (
     email TEXT,
     session_id TEXT
 );
+
+CREATE TABLE IF NOT EXISTS auth_users (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    first_name TEXT NOT NULL DEFAULT '',
+    last_name TEXT NOT NULL DEFAULT '',
+    role TEXT NOT NULL DEFAULT 'user',
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    last_login_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS auth_password_reset_codes (
+    email TEXT NOT NULL,
+    code TEXT NOT NULL,
+    expires_at BIGINT NOT NULL,
+    used_at BIGINT,
+    created_at BIGINT NOT NULL,
+    PRIMARY KEY (email, code)
+);
 """
 
 LOGBOOK_REQUIRED_FIELDS = ("site", "buddy", "guide")
 SAMPLE_TIME_UNIT_SECONDS = "seconds"
 SAMPLE_TIME_UNIT_MILLISECONDS = "milliseconds"
-CURRENT_SCHEMA_VERSION = 5
+CURRENT_SCHEMA_VERSION = 6
 SCHEMA_VERSION_SQL = """
 CREATE TABLE IF NOT EXISTS app_schema_version (
     singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
@@ -458,6 +480,39 @@ def apply_schema_migration_v5(cur: psycopg.Cursor) -> None:
     cur.execute("ALTER TABLE user_profile_buddies DROP COLUMN IF EXISTS sort_order")
 
 
+def apply_schema_migration_v6(cur: psycopg.Cursor) -> None:
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS auth_users (
+            id TEXT PRIMARY KEY,
+            email TEXT NOT NULL UNIQUE,
+            password_hash TEXT NOT NULL,
+            first_name TEXT NOT NULL DEFAULT '',
+            last_name TEXT NOT NULL DEFAULT '',
+            role TEXT NOT NULL DEFAULT 'user',
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_login_at TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS auth_password_reset_codes (
+            email TEXT NOT NULL,
+            code TEXT NOT NULL,
+            expires_at BIGINT NOT NULL,
+            used_at BIGINT,
+            created_at BIGINT NOT NULL,
+            PRIMARY KEY (email, code)
+        )
+        """
+    )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_auth_users_email ON auth_users (LOWER(email))")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_auth_password_reset_codes_expires_at ON auth_password_reset_codes (expires_at)")
+
+
 def _run_schema_migrations(conn: psycopg.Connection, cur: psycopg.Cursor, current_version: int) -> int:
     migrations: tuple[tuple[int, Callable[[psycopg.Connection, psycopg.Cursor], None]], ...] = (
         (1, lambda _conn, migration_cur: apply_schema_migration_v1(migration_cur)),
@@ -465,6 +520,7 @@ def _run_schema_migrations(conn: psycopg.Connection, cur: psycopg.Cursor, curren
         (3, apply_schema_migration_v3),
         (4, lambda _conn, migration_cur: apply_schema_migration_v4(migration_cur)),
         (5, lambda _conn, migration_cur: apply_schema_migration_v5(migration_cur)),
+        (6, lambda _conn, migration_cur: apply_schema_migration_v6(migration_cur)),
     )
     target_schema_version = min(CURRENT_SCHEMA_VERSION, max(version for version, _ in migrations))
 
@@ -1999,3 +2055,161 @@ def decode_base64_payload(payload: dict) -> bytes:
         return base64.b64decode(payload["raw_data_b64"], validate=True)
     except (ValueError, binascii.Error) as exc:
         raise ValueError("raw_data_b64 must be valid base64") from exc
+
+
+def normalize_email(value: object) -> str:
+    return clean_profile_text(value).strip().lower()
+
+
+def count_auth_users(conn: psycopg.Connection) -> int:
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) AS count FROM auth_users")
+        row = cur.fetchone() or {}
+    return int((row or {}).get("count") or 0)
+
+
+def get_auth_user_by_email(conn: psycopg.Connection, email: str) -> dict | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT * FROM auth_users WHERE LOWER(email)=LOWER(%s)", (normalize_email(email),))
+        return cur.fetchone()
+
+
+def get_auth_user_by_id(conn: psycopg.Connection, user_id: str) -> dict | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT * FROM auth_users WHERE id=%s", (clean_profile_text(user_id),))
+        return cur.fetchone()
+
+
+def create_auth_user(conn: psycopg.Connection, *, user_id: str, email: str, password_hash: str, first_name: str, last_name: str, role: str) -> dict:
+    now_value = now_iso()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO auth_users(id, email, password_hash, first_name, last_name, role, is_active, created_at, updated_at, last_login_at)
+            VALUES (%s, %s, %s, %s, %s, %s, TRUE, %s, %s, NULL)
+            """,
+            (
+                clean_profile_text(user_id),
+                normalize_email(email),
+                clean_profile_text(password_hash),
+                clean_profile_text(first_name),
+                clean_profile_text(last_name),
+                clean_profile_text(role) or "user",
+                now_value,
+                now_value,
+            ),
+        )
+    conn.commit()
+    return get_auth_user_by_id(conn, user_id) or {}
+
+
+def upsert_auth_user(conn: psycopg.Connection, *, user_id: str, email: str, password_hash: str, first_name: str, last_name: str, role: str, is_active: bool = True) -> dict:
+    now_value = now_iso()
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO auth_users(id, email, password_hash, first_name, last_name, role, is_active, created_at, updated_at, last_login_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NULL)
+            ON CONFLICT (id) DO UPDATE SET
+                email=excluded.email,
+                password_hash=excluded.password_hash,
+                first_name=excluded.first_name,
+                last_name=excluded.last_name,
+                role=excluded.role,
+                is_active=excluded.is_active,
+                updated_at=excluded.updated_at
+            """,
+            (
+                clean_profile_text(user_id),
+                normalize_email(email),
+                clean_profile_text(password_hash),
+                clean_profile_text(first_name),
+                clean_profile_text(last_name),
+                clean_profile_text(role) or "user",
+                bool(is_active),
+                now_value,
+                now_value,
+            ),
+        )
+    conn.commit()
+    return get_auth_user_by_id(conn, user_id) or {}
+
+
+def update_auth_user_last_login(conn: psycopg.Connection, user_id: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute("UPDATE auth_users SET last_login_at=%s, updated_at=%s WHERE id=%s", (now_iso(), now_iso(), clean_profile_text(user_id)))
+    conn.commit()
+
+
+def list_auth_users(conn: psycopg.Connection) -> list[dict]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, email, first_name, last_name, role, is_active, created_at, updated_at, last_login_at
+            FROM auth_users
+            ORDER BY created_at ASC, email ASC
+            """
+        )
+        rows = cur.fetchall() or []
+    return [dict(row) for row in rows]
+
+
+def update_auth_user(conn: psycopg.Connection, user_id: str, payload: dict) -> dict | None:
+    existing = get_auth_user_by_id(conn, user_id)
+    if not existing:
+        return None
+    next_email = normalize_email(payload.get("email")) if "email" in payload else existing.get("email")
+    next_first_name = clean_profile_text(payload.get("first_name")) if "first_name" in payload else clean_profile_text(existing.get("first_name"))
+    next_last_name = clean_profile_text(payload.get("last_name")) if "last_name" in payload else clean_profile_text(existing.get("last_name"))
+    next_role = clean_profile_text(payload.get("role")) if "role" in payload else clean_profile_text(existing.get("role"))
+    next_is_active = bool(payload.get("is_active")) if "is_active" in payload else bool(existing.get("is_active"))
+    next_password_hash = clean_profile_text(payload.get("password_hash")) if "password_hash" in payload else clean_profile_text(existing.get("password_hash"))
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE auth_users
+            SET email=%s, first_name=%s, last_name=%s, role=%s, is_active=%s, password_hash=%s, updated_at=%s
+            WHERE id=%s
+            """,
+            (next_email, next_first_name, next_last_name, next_role or "user", next_is_active, next_password_hash, now_iso(), clean_profile_text(user_id)),
+        )
+    conn.commit()
+    return get_auth_user_by_id(conn, user_id)
+
+
+def delete_auth_user(conn: psycopg.Connection, user_id: str) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM auth_users WHERE id=%s", (clean_profile_text(user_id),))
+        deleted = cur.rowcount > 0
+    conn.commit()
+    return deleted
+
+
+def create_password_reset_code(conn: psycopg.Connection, *, email: str, code: str, expires_at: int, now_timestamp: int) -> None:
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM auth_password_reset_codes WHERE expires_at <= %s OR used_at IS NOT NULL", (now_timestamp,))
+        cur.execute(
+            """
+            INSERT INTO auth_password_reset_codes(email, code, expires_at, used_at, created_at)
+            VALUES (%s, %s, %s, NULL, %s)
+            """,
+            (normalize_email(email), clean_profile_text(code), int(expires_at), int(now_timestamp)),
+        )
+    conn.commit()
+
+
+def consume_password_reset_code(conn: psycopg.Connection, *, email: str, code: str, now_timestamp: int) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM auth_password_reset_codes WHERE expires_at <= %s", (now_timestamp,))
+        cur.execute(
+            """
+            UPDATE auth_password_reset_codes
+            SET used_at=%s
+            WHERE LOWER(email)=LOWER(%s) AND code=%s AND used_at IS NULL AND expires_at > %s
+            """,
+            (now_timestamp, normalize_email(email), clean_profile_text(code), now_timestamp),
+        )
+        matched = cur.rowcount > 0
+    conn.commit()
+    return matched

--- a/backend/divevault/postgres_store.py
+++ b/backend/divevault/postgres_store.py
@@ -5,6 +5,7 @@ import binascii
 import json
 import re
 import secrets
+import time
 from collections.abc import Callable
 from datetime import datetime, timezone
 
@@ -124,20 +125,31 @@ CREATE TABLE IF NOT EXISTS auth_users (
     last_login_at TEXT
 );
 
-CREATE TABLE IF NOT EXISTS auth_password_reset_codes (
+CREATE TABLE IF NOT EXISTS auth_instance_settings (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    initialized BOOLEAN NOT NULL DEFAULT FALSE,
+    public_registration_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    owner_user_id TEXT,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS auth_user_invites (
+    token TEXT PRIMARY KEY,
     email TEXT NOT NULL,
-    code TEXT NOT NULL,
-    expires_at BIGINT NOT NULL,
-    used_at BIGINT,
+    first_name TEXT NOT NULL DEFAULT '',
+    last_name TEXT NOT NULL DEFAULT '',
+    role TEXT NOT NULL DEFAULT 'user',
+    invited_by_user_id TEXT NOT NULL,
     created_at BIGINT NOT NULL,
-    PRIMARY KEY (email, code)
+    expires_at BIGINT NOT NULL,
+    accepted_at BIGINT
 );
 """
 
 LOGBOOK_REQUIRED_FIELDS = ("site", "buddy", "guide")
 SAMPLE_TIME_UNIT_SECONDS = "seconds"
 SAMPLE_TIME_UNIT_MILLISECONDS = "milliseconds"
-CURRENT_SCHEMA_VERSION = 6
+CURRENT_SCHEMA_VERSION = 7
 SCHEMA_VERSION_SQL = """
 CREATE TABLE IF NOT EXISTS app_schema_version (
     singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
@@ -497,20 +509,60 @@ def apply_schema_migration_v6(cur: psycopg.Cursor) -> None:
         )
         """
     )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_auth_users_email ON auth_users (LOWER(email))")
+
+
+def apply_schema_migration_v7(cur: psycopg.Cursor) -> None:
     cur.execute(
         """
-        CREATE TABLE IF NOT EXISTS auth_password_reset_codes (
-            email TEXT NOT NULL,
-            code TEXT NOT NULL,
-            expires_at BIGINT NOT NULL,
-            used_at BIGINT,
-            created_at BIGINT NOT NULL,
-            PRIMARY KEY (email, code)
+        CREATE TABLE IF NOT EXISTS auth_instance_settings (
+            singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+            initialized BOOLEAN NOT NULL DEFAULT FALSE,
+            public_registration_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+            owner_user_id TEXT,
+            updated_at TEXT NOT NULL
         )
         """
     )
-    cur.execute("CREATE INDEX IF NOT EXISTS idx_auth_users_email ON auth_users (LOWER(email))")
-    cur.execute("CREATE INDEX IF NOT EXISTS idx_auth_password_reset_codes_expires_at ON auth_password_reset_codes (expires_at)")
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS auth_user_invites (
+            token TEXT PRIMARY KEY,
+            email TEXT NOT NULL,
+            first_name TEXT NOT NULL DEFAULT '',
+            last_name TEXT NOT NULL DEFAULT '',
+            role TEXT NOT NULL DEFAULT 'user',
+            invited_by_user_id TEXT NOT NULL,
+            created_at BIGINT NOT NULL,
+            expires_at BIGINT NOT NULL,
+            accepted_at BIGINT
+        )
+        """
+    )
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_auth_user_invites_expires_at ON auth_user_invites (expires_at)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_auth_user_invites_email ON auth_user_invites (LOWER(email))")
+    cur.execute(
+        """
+        INSERT INTO auth_instance_settings(singleton, initialized, public_registration_enabled, owner_user_id, updated_at)
+        VALUES (TRUE, FALSE, FALSE, NULL, %s)
+        ON CONFLICT (singleton) DO NOTHING
+        """,
+        (now_iso(),),
+    )
+    cur.execute("SELECT id FROM auth_users ORDER BY created_at ASC, email ASC LIMIT 1")
+    owner_row = cur.fetchone() or {}
+    owner_user_id = owner_row.get("id") if isinstance(owner_row, dict) else None
+    if owner_user_id:
+        cur.execute(
+            """
+            UPDATE auth_instance_settings
+            SET initialized=TRUE,
+                owner_user_id=COALESCE(owner_user_id, %s),
+                updated_at=%s
+            WHERE singleton=TRUE
+            """,
+            (clean_profile_text(owner_user_id), now_iso()),
+        )
 
 
 def _run_schema_migrations(conn: psycopg.Connection, cur: psycopg.Cursor, current_version: int) -> int:
@@ -521,6 +573,7 @@ def _run_schema_migrations(conn: psycopg.Connection, cur: psycopg.Cursor, curren
         (4, lambda _conn, migration_cur: apply_schema_migration_v4(migration_cur)),
         (5, lambda _conn, migration_cur: apply_schema_migration_v5(migration_cur)),
         (6, lambda _conn, migration_cur: apply_schema_migration_v6(migration_cur)),
+        (7, lambda _conn, migration_cur: apply_schema_migration_v7(migration_cur)),
     )
     target_schema_version = min(CURRENT_SCHEMA_VERSION, max(version for version, _ in migrations))
 
@@ -2061,6 +2114,272 @@ def normalize_email(value: object) -> str:
     return clean_profile_text(value).strip().lower()
 
 
+def _ensure_auth_instance_settings_row(cur: psycopg.Cursor) -> None:
+    cur.execute(
+        """
+        INSERT INTO auth_instance_settings(singleton, initialized, public_registration_enabled, owner_user_id, updated_at)
+        VALUES (TRUE, FALSE, FALSE, NULL, %s)
+        ON CONFLICT (singleton) DO NOTHING
+        """,
+        (now_iso(),),
+    )
+
+
+def get_auth_instance_settings(conn: psycopg.Connection) -> dict:
+    with conn.cursor() as cur:
+        _ensure_auth_instance_settings_row(cur)
+        cur.execute(
+            """
+            SELECT initialized, public_registration_enabled, owner_user_id, updated_at
+            FROM auth_instance_settings
+            WHERE singleton=TRUE
+            """
+        )
+        row = cur.fetchone() or {}
+        cur.execute("SELECT COUNT(*) AS count FROM auth_users")
+        count_row = cur.fetchone() or {}
+    conn.commit()
+    user_count = int((count_row or {}).get("count") or 0)
+    initialized = bool((row or {}).get("initialized"))
+    public_registration_enabled = bool((row or {}).get("public_registration_enabled"))
+    bootstrap_registration_open = (not initialized) and user_count == 0
+    return {
+        "initialized": initialized,
+        "public_registration_enabled": public_registration_enabled,
+        "owner_user_id": clean_profile_text((row or {}).get("owner_user_id")),
+        "updated_at": (row or {}).get("updated_at"),
+        "user_count": user_count,
+        "bootstrap_registration_open": bootstrap_registration_open,
+        "public_registration_open": bootstrap_registration_open or public_registration_enabled,
+    }
+
+
+def update_auth_instance_settings(
+    conn: psycopg.Connection,
+    *,
+    public_registration_enabled: bool | None = None,
+    initialized: bool | None = None,
+    owner_user_id: str | None = None,
+) -> dict:
+    with conn.cursor() as cur:
+        _ensure_auth_instance_settings_row(cur)
+        cur.execute(
+            """
+            SELECT initialized, public_registration_enabled, owner_user_id
+            FROM auth_instance_settings
+            WHERE singleton=TRUE
+            FOR UPDATE
+            """
+        )
+        existing = cur.fetchone() or {}
+        next_initialized = bool(existing.get("initialized")) if initialized is None else bool(initialized)
+        next_public_registration_enabled = (
+            bool(existing.get("public_registration_enabled"))
+            if public_registration_enabled is None
+            else bool(public_registration_enabled)
+        )
+        next_owner_user_id = clean_profile_text(existing.get("owner_user_id")) if owner_user_id is None else clean_profile_text(owner_user_id)
+        cur.execute(
+            """
+            UPDATE auth_instance_settings
+            SET initialized=%s,
+                public_registration_enabled=%s,
+                owner_user_id=%s,
+                updated_at=%s
+            WHERE singleton=TRUE
+            """,
+            (next_initialized, next_public_registration_enabled, next_owner_user_id or None, now_iso()),
+        )
+    conn.commit()
+    return get_auth_instance_settings(conn)
+
+
+def create_bootstrap_auth_user(
+    conn: psycopg.Connection,
+    *,
+    user_id: str,
+    email: str,
+    password_hash: str,
+    first_name: str,
+    last_name: str,
+) -> dict:
+    normalized_email = normalize_email(email)
+    now_value = now_iso()
+    with conn.cursor() as cur:
+        _ensure_auth_instance_settings_row(cur)
+        cur.execute(
+            """
+            SELECT initialized, owner_user_id
+            FROM auth_instance_settings
+            WHERE singleton=TRUE
+            FOR UPDATE
+            """
+        )
+        settings = cur.fetchone() or {}
+        cur.execute("SELECT COUNT(*) AS count FROM auth_users")
+        count_row = cur.fetchone() or {}
+        user_count = int((count_row or {}).get("count") or 0)
+        if bool(settings.get("initialized")) or user_count > 0:
+            raise ValueError("Public registration is closed")
+        cur.execute("SELECT 1 FROM auth_users WHERE LOWER(email)=LOWER(%s)", (normalized_email,))
+        if cur.fetchone():
+            raise ValueError("Email already registered")
+        cur.execute(
+            """
+            INSERT INTO auth_users(id, email, password_hash, first_name, last_name, role, is_active, created_at, updated_at, last_login_at)
+            VALUES (%s, %s, %s, %s, %s, 'admin', TRUE, %s, %s, NULL)
+            """,
+            (
+                clean_profile_text(user_id),
+                normalized_email,
+                clean_profile_text(password_hash),
+                clean_profile_text(first_name),
+                clean_profile_text(last_name),
+                now_value,
+                now_value,
+            ),
+        )
+        cur.execute(
+            """
+            UPDATE auth_instance_settings
+            SET initialized=TRUE,
+                owner_user_id=%s,
+                updated_at=%s
+            WHERE singleton=TRUE
+            """,
+            (clean_profile_text(user_id), now_iso()),
+        )
+    conn.commit()
+    return get_auth_user_by_id(conn, user_id) or {}
+
+
+def cleanup_auth_invites_with_cursor(cur: psycopg.Cursor, now_timestamp: int) -> None:
+    cur.execute(
+        """
+        DELETE FROM auth_user_invites
+        WHERE accepted_at IS NOT NULL OR expires_at <= %s
+        """,
+        (int(now_timestamp),),
+    )
+
+
+def create_auth_invite(
+    conn: psycopg.Connection,
+    *,
+    token: str,
+    email: str,
+    first_name: str,
+    last_name: str,
+    role: str,
+    invited_by_user_id: str,
+    expires_at: int,
+    now_timestamp: int,
+) -> dict:
+    with conn.cursor() as cur:
+        cleanup_auth_invites_with_cursor(cur, now_timestamp)
+        cur.execute("DELETE FROM auth_user_invites WHERE LOWER(email)=LOWER(%s)", (normalize_email(email),))
+        cur.execute(
+            """
+            INSERT INTO auth_user_invites(
+                token, email, first_name, last_name, role, invited_by_user_id, created_at, expires_at, accepted_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NULL)
+            """,
+            (
+                clean_profile_text(token),
+                normalize_email(email),
+                clean_profile_text(first_name),
+                clean_profile_text(last_name),
+                clean_profile_text(role) or "user",
+                clean_profile_text(invited_by_user_id),
+                int(now_timestamp),
+                int(expires_at),
+            ),
+        )
+        cur.execute(
+            """
+            SELECT token, email, first_name, last_name, role, invited_by_user_id, created_at, expires_at
+            FROM auth_user_invites
+            WHERE token=%s
+            """,
+            (clean_profile_text(token),),
+        )
+        row = cur.fetchone() or {}
+    conn.commit()
+    return dict(row)
+
+
+def get_auth_invite_by_token(conn: psycopg.Connection, token: str, *, now_timestamp: int) -> dict | None:
+    with conn.cursor() as cur:
+        cleanup_auth_invites_with_cursor(cur, now_timestamp)
+        cur.execute(
+            """
+            SELECT token, email, first_name, last_name, role, invited_by_user_id, created_at, expires_at
+            FROM auth_user_invites
+            WHERE token=%s AND accepted_at IS NULL AND expires_at > %s
+            """,
+            (clean_profile_text(token), int(now_timestamp)),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    return dict(row) if row else None
+
+
+def create_auth_user_from_invite(
+    conn: psycopg.Connection,
+    *,
+    invite_token: str,
+    user_id: str,
+    password_hash: str,
+) -> dict:
+    now_value = now_iso()
+    now_timestamp = int(time.time())
+    with conn.cursor() as cur:
+        cleanup_auth_invites_with_cursor(cur, now_timestamp)
+        cur.execute(
+            """
+            SELECT token, email, first_name, last_name, role
+            FROM auth_user_invites
+            WHERE token=%s AND accepted_at IS NULL AND expires_at > %s
+            FOR UPDATE
+            """,
+            (clean_profile_text(invite_token), now_timestamp),
+        )
+        invite = cur.fetchone()
+        if not invite:
+            raise ValueError("Invitation is invalid or expired")
+        invite_email = normalize_email(invite.get("email"))
+        cur.execute("SELECT 1 FROM auth_users WHERE LOWER(email)=LOWER(%s)", (invite_email,))
+        if cur.fetchone():
+            raise ValueError("Email already registered")
+        cur.execute(
+            """
+            INSERT INTO auth_users(id, email, password_hash, first_name, last_name, role, is_active, created_at, updated_at, last_login_at)
+            VALUES (%s, %s, %s, %s, %s, %s, TRUE, %s, %s, NULL)
+            """,
+            (
+                clean_profile_text(user_id),
+                invite_email,
+                clean_profile_text(password_hash),
+                clean_profile_text(invite.get("first_name")),
+                clean_profile_text(invite.get("last_name")),
+                clean_profile_text(invite.get("role")) or "user",
+                now_value,
+                now_value,
+            ),
+        )
+        cur.execute(
+            """
+            UPDATE auth_user_invites
+            SET accepted_at=%s
+            WHERE token=%s
+            """,
+            (now_timestamp, clean_profile_text(invite_token)),
+        )
+    conn.commit()
+    return get_auth_user_by_id(conn, user_id) or {}
+
+
 def count_auth_users(conn: psycopg.Connection) -> int:
     with conn.cursor() as cur:
         cur.execute("SELECT COUNT(*) AS count FROM auth_users")
@@ -2184,32 +2503,3 @@ def delete_auth_user(conn: psycopg.Connection, user_id: str) -> bool:
         deleted = cur.rowcount > 0
     conn.commit()
     return deleted
-
-
-def create_password_reset_code(conn: psycopg.Connection, *, email: str, code: str, expires_at: int, now_timestamp: int) -> None:
-    with conn.cursor() as cur:
-        cur.execute("DELETE FROM auth_password_reset_codes WHERE expires_at <= %s OR used_at IS NOT NULL", (now_timestamp,))
-        cur.execute(
-            """
-            INSERT INTO auth_password_reset_codes(email, code, expires_at, used_at, created_at)
-            VALUES (%s, %s, %s, NULL, %s)
-            """,
-            (normalize_email(email), clean_profile_text(code), int(expires_at), int(now_timestamp)),
-        )
-    conn.commit()
-
-
-def consume_password_reset_code(conn: psycopg.Connection, *, email: str, code: str, now_timestamp: int) -> bool:
-    with conn.cursor() as cur:
-        cur.execute("DELETE FROM auth_password_reset_codes WHERE expires_at <= %s", (now_timestamp,))
-        cur.execute(
-            """
-            UPDATE auth_password_reset_codes
-            SET used_at=%s
-            WHERE LOWER(email)=LOWER(%s) AND code=%s AND used_at IS NULL AND expires_at > %s
-            """,
-            (now_timestamp, normalize_email(email), clean_profile_text(code), now_timestamp),
-        )
-        matched = cur.rowcount > 0
-    conn.commit()
-    return matched

--- a/backend/migrations/migrate_clerk_users_to_auth.py
+++ b/backend/migrations/migrate_clerk_users_to_auth.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Manually migrate exported Clerk users into DiveVault auth_users.
+
+Usage:
+  python backend/migrations/migrate_clerk_users_to_auth.py \
+    --database-url postgresql://... \
+    --input ./clerk-users.json \
+    --default-password 'ChangeMe123!'
+
+Input JSON format:
+[
+  {
+    "id": "user_2abc...",          # required, keep Clerk user id to preserve existing per-user data ownership
+    "email": "diver@example.com",  # required
+    "first_name": "Ava",           # optional
+    "last_name": "Diver",          # optional
+    "role": "admin",               # optional (default: user)
+    "password": "optional-per-user-password",
+    "is_active": true                # optional (default: true)
+  }
+]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import secrets
+from pathlib import Path
+
+from divevault.app import hash_password
+from divevault.postgres_store import open_db, upsert_auth_user
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Import Clerk users into DiveVault's first-party auth table")
+    parser.add_argument("--database-url", required=True, help="PostgreSQL connection string")
+    parser.add_argument("--input", required=True, help="Path to JSON array of exported users")
+    parser.add_argument("--default-password", default="", help="Fallback password when a row omits password")
+    parser.add_argument("--dry-run", action="store_true", help="Validate input without writing to database")
+    return parser.parse_args()
+
+
+def random_password() -> str:
+    return secrets.token_urlsafe(14) + "!A1"
+
+
+def main() -> None:
+    args = parse_args()
+    rows = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    if not isinstance(rows, list):
+        raise SystemExit("Input must be a JSON array")
+
+    generated_passwords: list[tuple[str, str]] = []
+
+    if args.dry_run:
+        print(f"Validated {len(rows)} users (dry-run).")
+        return
+
+    conn = open_db(args.database_url)
+    try:
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            user_id = str(row.get("id") or "").strip()
+            email = str(row.get("email") or "").strip().lower()
+            if not user_id or not email:
+                continue
+
+            raw_password = str(row.get("password") or args.default_password or "").strip()
+            if not raw_password:
+                raw_password = random_password()
+                generated_passwords.append((email, raw_password))
+
+            upsert_auth_user(
+                conn,
+                user_id=user_id,
+                email=email,
+                password_hash=hash_password(raw_password),
+                first_name=str(row.get("first_name") or "").strip(),
+                last_name=str(row.get("last_name") or "").strip(),
+                role=str(row.get("role") or "user").strip().lower() or "user",
+                is_active=bool(row.get("is_active", True)),
+            )
+    finally:
+        conn.close()
+
+    print(f"Imported {len(rows)} users into auth_users.")
+    if generated_passwords:
+        print("Generated temporary passwords (rotate after first login):")
+        for email, password in generated_passwords:
+            print(f"  {email}: {password}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/migrations/remap_legacy_user_ids.py
+++ b/backend/migrations/remap_legacy_user_ids.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Remap DiveVault data from legacy user ids to existing internal auth users.
+
+Use this when you already created replacement users in DiveVault auth_users and need
+to move all application-owned rows from the old ids to the new ids.
+
+Input JSON format:
+[
+  {
+    "old_user_id": "user_old_clerk_id",
+    "new_user_id": "user_new_internal_id",
+    "email": "optional@example.com"
+  }
+]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BACKEND_ROOT.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from divevault.postgres_store import open_db
+
+
+STRICT_USER_ID_TABLES: tuple[tuple[str, str], ...] = (
+    ("device_state", "user_id"),
+    ("dives", "user_id"),
+    ("user_profile", "user_id"),
+    ("user_profile_license_documents", "user_id"),
+    ("user_profile_licenses", "user_id"),
+    ("user_profile_dive_sites", "user_id"),
+    ("user_profile_buddies", "user_id"),
+    ("user_profile_guides", "user_id"),
+)
+
+REFERENCE_USER_ID_TABLES: tuple[tuple[str, str], ...] = (
+    ("cli_sync_auth_requests", "user_id"),
+    ("auth_instance_settings", "owner_user_id"),
+    ("auth_user_invites", "invited_by_user_id"),
+)
+
+
+@dataclass(frozen=True)
+class UserIdRemap:
+    old_user_id: str
+    new_user_id: str
+    email: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Remap legacy DiveVault user ids to existing internal auth user ids")
+    parser.add_argument("--database-url", required=True, help="PostgreSQL connection string")
+    parser.add_argument("--input", required=True, help="Path to JSON remap file")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and report without writing changes")
+    parser.add_argument(
+        "--delete-old-auth-users",
+        action="store_true",
+        help="Delete matching old auth_users rows after remapping. Use only when replacement users already exist in auth_users.",
+    )
+    return parser.parse_args()
+
+
+def _clean_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_email(value: object) -> str:
+    return _clean_text(value).lower()
+
+
+def load_remaps(path: Path) -> list[UserIdRemap]:
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(rows, list):
+        raise SystemExit("Input must be a JSON array")
+
+    remaps: list[UserIdRemap] = []
+    for index, row in enumerate(rows, start=1):
+        if not isinstance(row, dict):
+            raise SystemExit(f"Input row {index} must be an object")
+        old_user_id = _clean_text(row.get("old_user_id") or row.get("old_id") or row.get("from_user_id"))
+        new_user_id = _clean_text(row.get("new_user_id") or row.get("new_id") or row.get("to_user_id"))
+        email = _normalize_email(row.get("email"))
+        if not old_user_id or not new_user_id:
+            raise SystemExit(f"Input row {index} must include old_user_id and new_user_id")
+        if old_user_id == new_user_id:
+            raise SystemExit(f"Input row {index} maps {old_user_id!r} to itself; remove it from the remap file")
+        remaps.append(UserIdRemap(old_user_id=old_user_id, new_user_id=new_user_id, email=email))
+
+    old_ids = [item.old_user_id for item in remaps]
+    new_ids = [item.new_user_id for item in remaps]
+    if len(set(old_ids)) != len(old_ids):
+        raise SystemExit("Each old_user_id must appear only once")
+    if len(set(new_ids)) != len(new_ids):
+        raise SystemExit("Each new_user_id must appear only once")
+    overlap = set(old_ids) & set(new_ids)
+    if overlap:
+        overlap_list = ", ".join(sorted(overlap))
+        raise SystemExit(
+            "For safety this script requires old and new id sets to be disjoint. "
+            f"Overlapping ids: {overlap_list}"
+        )
+    return remaps
+
+
+def count_rows(cur, table: str, column: str, user_id: str) -> int:
+    cur.execute(f"SELECT COUNT(*) AS count FROM {table} WHERE {column}=%s", (user_id,))
+    row = cur.fetchone() or {}
+    return int((row or {}).get("count") or 0)
+
+
+def validate_remaps(cur, remaps: list[UserIdRemap]) -> list[str]:
+    report_lines: list[str] = []
+
+    for remap in remaps:
+        cur.execute("SELECT id, email FROM auth_users WHERE id=%s", (remap.new_user_id,))
+        new_auth_user = cur.fetchone()
+        if not new_auth_user:
+            raise SystemExit(f"Target auth user {remap.new_user_id!r} does not exist in auth_users")
+        target_email = _normalize_email(new_auth_user.get("email"))
+        if remap.email and remap.email != target_email:
+            raise SystemExit(
+                f"Target auth user {remap.new_user_id!r} has email {target_email!r}, "
+                f"but the remap file expected {remap.email!r}"
+            )
+
+        cur.execute("SELECT id, email FROM auth_users WHERE id=%s", (remap.old_user_id,))
+        old_auth_user = cur.fetchone()
+
+        report_lines.append(f"{remap.old_user_id} -> {remap.new_user_id} ({target_email or 'no target email'})")
+        report_lines.append(
+            f"  auth_users: old_exists={'yes' if old_auth_user else 'no'} new_exists=yes"
+        )
+
+        conflicting_tables: list[str] = []
+        for table, column in STRICT_USER_ID_TABLES:
+            old_count = count_rows(cur, table, column, remap.old_user_id)
+            new_count = count_rows(cur, table, column, remap.new_user_id)
+            report_lines.append(f"  {table}: source_rows={old_count} target_rows={new_count}")
+            if new_count > 0:
+                conflicting_tables.append(table)
+
+        for table, column in REFERENCE_USER_ID_TABLES:
+            old_count = count_rows(cur, table, column, remap.old_user_id)
+            new_count = count_rows(cur, table, column, remap.new_user_id)
+            report_lines.append(f"  {table}: source_refs={old_count} target_refs={new_count}")
+
+        if conflicting_tables:
+            joined = ", ".join(conflicting_tables)
+            raise SystemExit(
+                f"Refusing to remap {remap.old_user_id!r} -> {remap.new_user_id!r} because the target id already owns rows in: {joined}. "
+                "Clean up those target-owned rows first, then rerun."
+            )
+
+    return report_lines
+
+
+def apply_remaps(cur, remaps: list[UserIdRemap], *, delete_old_auth_users: bool) -> list[str]:
+    summary: list[str] = []
+    for remap in remaps:
+        updated_counts: list[str] = []
+        for table, column in STRICT_USER_ID_TABLES + REFERENCE_USER_ID_TABLES:
+            cur.execute(f"UPDATE {table} SET {column}=%s WHERE {column}=%s", (remap.new_user_id, remap.old_user_id))
+            if cur.rowcount:
+                updated_counts.append(f"{table}={cur.rowcount}")
+        if delete_old_auth_users:
+            cur.execute("DELETE FROM auth_users WHERE id=%s", (remap.old_user_id,))
+            if cur.rowcount:
+                updated_counts.append(f"auth_users_deleted={cur.rowcount}")
+        summary.append(f"{remap.old_user_id} -> {remap.new_user_id}: " + (", ".join(updated_counts) or "no rows changed"))
+    return summary
+
+
+def main() -> None:
+    args = parse_args()
+    remaps = load_remaps(Path(args.input))
+
+    conn = open_db(args.database_url)
+    try:
+        with conn.cursor() as cur:
+            report_lines = validate_remaps(cur, remaps)
+
+        print("Preflight report:")
+        for line in report_lines:
+            print(line)
+
+        if args.dry_run:
+            conn.rollback()
+            print("Dry run only. No changes were written.")
+            return
+
+        # The preflight SELECTs open an implicit transaction on psycopg connections.
+        # End that transaction before starting the write transaction so the remap
+        # actually commits instead of being left inside an outer uncommitted block.
+        conn.rollback()
+        with conn.transaction():
+            with conn.cursor() as cur:
+                summary_lines = apply_remaps(cur, remaps, delete_old_auth_users=bool(args.delete_old_auth_users))
+
+        print("Remap completed:")
+        for line in summary_lines:
+            print(line)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_dive_backend_endpoints.py
+++ b/backend/tests/test_dive_backend_endpoints.py
@@ -29,13 +29,14 @@ class FakeVerifier:
         authorization = headers.get("Authorization", "")
         token = authorization.split(" ", 1)[1].strip() if authorization.lower().startswith("bearer ") else ""
         if not token:
-            raise dive_backend.ClerkAuthError(401, "Missing Clerk bearer token")
+            raise dive_backend.AuthError(401, "Missing authentication bearer token")
         if token == "session":
             return {
                 "token_type": "session_token",
                 "sid": "sid_123",
                 "sub": "user-1",
                 "email": "diver@example.com",
+                "role": "admin",
             }
         if token == "api":
             return {
@@ -45,7 +46,7 @@ class FakeVerifier:
             }
         if token == "nouser":
             return {"token_type": "session_token"}
-        raise dive_backend.ClerkAuthError(401, "Invalid token")
+        raise dive_backend.AuthError(401, "Invalid token")
 
 
 class FakeCliAuthManager:
@@ -101,6 +102,27 @@ class FakeNominatimClient:
 @pytest.fixture()
 def server_fixture(monkeypatch):
     store = {
+        "auth_users": [
+            {
+                "id": "user-1",
+                "email": "diver@example.com",
+                "password_hash": dive_backend.hash_password("password123"),
+                "first_name": "Elias",
+                "last_name": "Thorne",
+                "role": "admin",
+                "is_active": True,
+                "created_at": "2026-03-20T08:00:00+00:00",
+                "updated_at": "2026-03-20T08:00:00+00:00",
+                "last_login_at": None,
+            }
+        ],
+        "auth_settings": {
+            "initialized": True,
+            "public_registration_enabled": False,
+            "owner_user_id": "user-1",
+            "updated_at": "2026-03-20T08:00:00+00:00",
+        },
+        "auth_invites": {},
         "dives": [
             {
                 "id": 1,
@@ -363,7 +385,168 @@ def server_fixture(monkeypatch):
             {"totalDives": len(public_dives)},
         )
 
+    def compute_auth_settings():
+        user_count = len(store["auth_users"])
+        initialized = bool(store["auth_settings"].get("initialized"))
+        public_registration_enabled = bool(store["auth_settings"].get("public_registration_enabled"))
+        bootstrap_registration_open = (not initialized) and user_count == 0
+        return {
+            "initialized": initialized,
+            "public_registration_enabled": public_registration_enabled,
+            "owner_user_id": store["auth_settings"].get("owner_user_id"),
+            "updated_at": store["auth_settings"].get("updated_at"),
+            "user_count": user_count,
+            "bootstrap_registration_open": bootstrap_registration_open,
+            "public_registration_open": bootstrap_registration_open or public_registration_enabled,
+        }
+
+    def fake_count_auth_users(_conn):
+        return len(store["auth_users"])
+
+    def fake_get_auth_user_by_email(_conn, email: str):
+        normalized = str(email or "").strip().lower()
+        return next((dict(user) for user in store["auth_users"] if user["email"].lower() == normalized), None)
+
+    def fake_get_auth_user_by_id(_conn, user_id: str):
+        return next((dict(user) for user in store["auth_users"] if user["id"] == user_id), None)
+
+    def fake_create_auth_user(_conn, *, user_id: str, email: str, password_hash: str, first_name: str, last_name: str, role: str):
+        user = {
+            "id": user_id,
+            "email": email.strip().lower(),
+            "password_hash": password_hash,
+            "first_name": first_name.strip(),
+            "last_name": last_name.strip(),
+            "role": role,
+            "is_active": True,
+            "created_at": "2026-03-21T08:00:00+00:00",
+            "updated_at": "2026-03-21T08:00:00+00:00",
+            "last_login_at": None,
+        }
+        store["auth_users"].append(user)
+        return dict(user)
+
+    def fake_create_bootstrap_auth_user(_conn, *, user_id: str, email: str, password_hash: str, first_name: str, last_name: str):
+        settings = compute_auth_settings()
+        if not settings["bootstrap_registration_open"]:
+            raise ValueError("Public registration is closed")
+        user = fake_create_auth_user(
+            _conn,
+            user_id=user_id,
+            email=email,
+            password_hash=password_hash,
+            first_name=first_name,
+            last_name=last_name,
+            role="admin",
+        )
+        store["auth_settings"]["initialized"] = True
+        store["auth_settings"]["owner_user_id"] = user_id
+        return user
+
+    def fake_get_auth_instance_settings(_conn):
+        return compute_auth_settings()
+
+    def fake_update_auth_instance_settings(_conn, *, public_registration_enabled=None, initialized=None, owner_user_id=None):
+        if public_registration_enabled is not None:
+            store["auth_settings"]["public_registration_enabled"] = bool(public_registration_enabled)
+        if initialized is not None:
+            store["auth_settings"]["initialized"] = bool(initialized)
+        if owner_user_id is not None:
+            store["auth_settings"]["owner_user_id"] = owner_user_id
+        store["auth_settings"]["updated_at"] = "2026-03-21T08:05:00+00:00"
+        return compute_auth_settings()
+
+    def fake_create_auth_invite(_conn, *, token: str, email: str, first_name: str, last_name: str, role: str, invited_by_user_id: str, expires_at: int, now_timestamp: int):
+        invite = {
+            "token": token,
+            "email": email.strip().lower(),
+            "first_name": first_name.strip(),
+            "last_name": last_name.strip(),
+            "role": role,
+            "invited_by_user_id": invited_by_user_id,
+            "created_at": now_timestamp,
+            "expires_at": expires_at,
+            "accepted_at": None,
+        }
+        store["auth_invites"][token] = invite
+        return {key: invite[key] for key in ("token", "email", "first_name", "last_name", "role", "invited_by_user_id", "created_at", "expires_at")}
+
+    def fake_get_auth_invite_by_token(_conn, token: str, *, now_timestamp: int):
+        invite = store["auth_invites"].get(token)
+        if not invite or invite.get("accepted_at") is not None or int(invite.get("expires_at") or 0) <= now_timestamp:
+            return None
+        return {key: invite[key] for key in ("token", "email", "first_name", "last_name", "role", "invited_by_user_id", "created_at", "expires_at")}
+
+    def fake_create_auth_user_from_invite(_conn, *, invite_token: str, user_id: str, password_hash: str):
+        invite = store["auth_invites"].get(invite_token)
+        if not invite or invite.get("accepted_at") is not None:
+            raise ValueError("Invitation is invalid or expired")
+        if fake_get_auth_user_by_email(_conn, invite["email"]):
+            raise ValueError("Email already registered")
+        user = fake_create_auth_user(
+            _conn,
+            user_id=user_id,
+            email=invite["email"],
+            password_hash=password_hash,
+            first_name=invite.get("first_name") or "",
+            last_name=invite.get("last_name") or "",
+            role=invite.get("role") or "user",
+        )
+        invite["accepted_at"] = invite.get("created_at", 0) + 60
+        return user
+
+    def fake_update_auth_user_last_login(_conn, user_id: str):
+        for user in store["auth_users"]:
+            if user["id"] == user_id:
+                user["last_login_at"] = "2026-03-21T08:06:00+00:00"
+                user["updated_at"] = "2026-03-21T08:06:00+00:00"
+                return None
+        return None
+
+    def fake_list_auth_users(_conn):
+        return [
+            {
+                key: user[key]
+                for key in ("id", "email", "first_name", "last_name", "role", "is_active", "created_at", "updated_at", "last_login_at")
+            }
+            for user in store["auth_users"]
+        ]
+
+    def fake_update_auth_user(_conn, user_id: str, payload: dict):
+        for user in store["auth_users"]:
+            if user["id"] != user_id:
+                continue
+            for key in ("email", "first_name", "last_name", "role", "password_hash"):
+                if key in payload:
+                    user[key] = payload[key]
+            if "is_active" in payload:
+                user["is_active"] = bool(payload["is_active"])
+            user["updated_at"] = "2026-03-21T08:07:00+00:00"
+            return dict(user)
+        return None
+
+    def fake_delete_auth_user(_conn, user_id: str):
+        for index, user in enumerate(store["auth_users"]):
+            if user["id"] == user_id:
+                store["auth_users"].pop(index)
+                return True
+        return False
+
     monkeypatch.setattr(dive_backend, "open_db", fake_open_db)
+    monkeypatch.setattr(dive_backend, "count_auth_users", fake_count_auth_users)
+    monkeypatch.setattr(dive_backend, "get_auth_user_by_email", fake_get_auth_user_by_email)
+    monkeypatch.setattr(dive_backend, "get_auth_user_by_id", fake_get_auth_user_by_id)
+    monkeypatch.setattr(dive_backend, "create_auth_user", fake_create_auth_user)
+    monkeypatch.setattr(dive_backend, "create_bootstrap_auth_user", fake_create_bootstrap_auth_user)
+    monkeypatch.setattr(dive_backend, "get_auth_instance_settings", fake_get_auth_instance_settings)
+    monkeypatch.setattr(dive_backend, "update_auth_instance_settings", fake_update_auth_instance_settings)
+    monkeypatch.setattr(dive_backend, "create_auth_invite", fake_create_auth_invite)
+    monkeypatch.setattr(dive_backend, "get_auth_invite_by_token", fake_get_auth_invite_by_token)
+    monkeypatch.setattr(dive_backend, "create_auth_user_from_invite", fake_create_auth_user_from_invite)
+    monkeypatch.setattr(dive_backend, "update_auth_user_last_login", fake_update_auth_user_last_login)
+    monkeypatch.setattr(dive_backend, "list_auth_users", fake_list_auth_users)
+    monkeypatch.setattr(dive_backend, "update_auth_user", fake_update_auth_user)
+    monkeypatch.setattr(dive_backend, "delete_auth_user", fake_delete_auth_user)
     monkeypatch.setattr(dive_backend, "get_device_state", fake_get_device_state)
     monkeypatch.setattr(dive_backend, "save_device_state", fake_save_device_state)
     monkeypatch.setattr(dive_backend, "list_device_states", fake_list_device_states)
@@ -389,7 +572,8 @@ def server_fixture(monkeypatch):
         server.database_url = "postgresql://unused"
         server.database_ready = True
         server.database_ready_error = ""
-        server.clerk_verifier = FakeVerifier()
+        server.auth_verifier = FakeVerifier()
+        server.clerk_verifier = server.auth_verifier
         server.clerk_publishable_key = "pk_test_123"
         server.cors_origin = "http://localhost:5173"
         server.max_json_body_bytes = 1024 * 1024
@@ -406,6 +590,7 @@ def server_fixture(monkeypatch):
         server.frontend_dir = frontend_dir
         server.cli_auth_manager = FakeCliAuthManager()
         server.nominatim_client = FakeNominatimClient()
+        server.test_store = store
 
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
@@ -447,7 +632,7 @@ def test_get_and_options_routes(server_fixture):
 
     config = request(server, "GET", "/config.js")
     assert config.status == 200
-    assert "pk_test_123" in config.body.decode("utf-8")
+    assert '"authEnabled": true' in config.body.decode("utf-8")
 
     static_asset = request(server, "GET", "/asset.js")
     assert static_asset.status == 200
@@ -572,6 +757,141 @@ def test_health_reports_starting_until_database_ready(server_fixture):
         "database": "migrating",
         "error": "startup migrations still running",
     }
+
+
+def test_auth_status_and_owner_registration_controls(server_fixture):
+    server = server_fixture
+
+    status = request(server, "GET", "/api/auth/status")
+    assert status.status == 200
+    assert status.json() == {
+        "initialized": True,
+        "user_count": 1,
+        "bootstrap_registration_open": False,
+        "public_registration_enabled": False,
+        "public_registration_open": False,
+        "invite": None,
+    }
+
+    closed_registration = request(
+        server,
+        "POST",
+        "/api/auth/register",
+        payload={"email": "new@example.com", "password": "Password123!"},
+    )
+    assert closed_registration.status == 403
+    assert closed_registration.json()["error"] == "Public registration is closed"
+
+    get_settings = request(server, "GET", "/api/auth/settings", token="session")
+    assert get_settings.status == 200
+    assert get_settings.json()["owner_user_id"] == "user-1"
+
+    enable_registration = request(
+        server,
+        "PUT",
+        "/api/auth/settings",
+        token="session",
+        payload={"public_registration_enabled": True},
+    )
+    assert enable_registration.status == 200
+    assert enable_registration.json()["public_registration_enabled"] is True
+
+    open_registration = request(
+        server,
+        "POST",
+        "/api/auth/register",
+        payload={"email": "new@example.com", "password": "Password123!", "first_name": "New", "last_name": "Diver"},
+    )
+    assert open_registration.status == 201
+    assert open_registration.json()["email"] == "new@example.com"
+    assert open_registration.json()["role"] == "user"
+    assert open_registration.json()["is_owner"] is False
+
+
+def test_owner_can_invite_and_invited_user_can_register(server_fixture):
+    server = server_fixture
+
+    invite = request(
+        server,
+        "POST",
+        "/api/auth/invitations",
+        token="session",
+        payload={
+            "email": "invitee@example.com",
+            "first_name": "Ivy",
+            "last_name": "Guest",
+            "role": "user",
+            "expires_in_days": 3,
+        },
+    )
+    assert invite.status == 201
+    invite_payload = invite.json()
+    assert invite_payload["invite"]["email"] == "invitee@example.com"
+    assert "invite_token=" in invite_payload["invite_url"]
+
+    invite_token = invite_payload["invite"]["token"]
+    status = request(server, "GET", f"/api/auth/status?invite_token={invite_token}")
+    assert status.status == 200
+    assert status.json()["invite"]["email"] == "invitee@example.com"
+
+    accepted = request(
+        server,
+        "POST",
+        "/api/auth/register",
+        payload={
+            "email": "invitee@example.com",
+            "password": "Password123!",
+            "invite_token": invite_token,
+        },
+    )
+    assert accepted.status == 201
+    assert accepted.json()["email"] == "invitee@example.com"
+    assert accepted.json()["role"] == "user"
+
+    duplicate = request(
+        server,
+        "POST",
+        "/api/auth/register",
+        payload={
+            "email": "invitee@example.com",
+            "password": "Password123!",
+            "invite_token": invite_token,
+        },
+    )
+    assert duplicate.status == 400
+    assert duplicate.json()["error"] == "Invitation is invalid or expired"
+
+
+def test_bootstrap_registration_only_when_uninitialized(server_fixture):
+    server = server_fixture
+    server.test_store["auth_users"] = []
+    server.test_store["auth_settings"] = {
+        "initialized": False,
+        "public_registration_enabled": False,
+        "owner_user_id": None,
+        "updated_at": "2026-03-21T09:00:00+00:00",
+    }
+
+    register = request(
+        server,
+        "POST",
+        "/api/auth/register",
+        payload={
+            "email": "owner@example.com",
+            "password": "Password123!",
+            "first_name": "Olive",
+            "last_name": "Owner",
+        },
+    )
+    assert register.status == 201
+    assert register.json()["role"] == "admin"
+    assert register.json()["is_owner"] is True
+
+    status = request(server, "GET", "/api/auth/status")
+    assert status.status == 200
+    assert status.json()["initialized"] is True
+    assert status.json()["bootstrap_registration_open"] is False
+    assert status.json()["user_count"] == 1
 
 
 def test_post_and_put_endpoints(server_fixture):
@@ -998,22 +1318,30 @@ def test_route_manifest_requires_test_updates_for_new_endpoints():
         "/health",
         "/api/health",
         "/config.js",
+        "/api/auth/invitations",
+        "/api/auth/login",
+        "/api/auth/me",
+        "/api/auth/password",
+        "/api/auth/register",
+        "/api/auth/settings",
+        "/api/auth/status",
+        "/api/backup/export",
+        "/api/backup/import",
+        "/api/cli-auth/approve",
+        "/api/cli-auth/request",
         "/api/device-state",
-        "/api/profile",
         "/api/exports/dives.csv",
-            "/api/exports/dives.pdf",
-            "/api/backup/export",
-            "/api/geocode/search",
-            "/api/auth/me",
-            "/api/cli-auth/request",
-            "/api/dives",
-            "/api/backup/import",
-            "/api/cli-auth/approve",
-            "regex:/api/public/divers/([a-z0-9-]+)",
-            "regex:/api/dives/(\\d+)",
-            "regex:/api/dives/(\\d+)/logbook",
-            "regex:/api/profile/licenses/([A-Za-z0-9_-]+)/pdf",
+        "/api/exports/dives.pdf",
+        "/api/geocode/search",
+        "/api/profile",
+        "/api/users",
+        "/api/dives",
         "prefix:/api/*",
+        "regex:/api/dives/(\\d+)",
+        "regex:/api/dives/(\\d+)/logbook",
+        "regex:/api/profile/licenses/([A-Za-z0-9_-]+)/pdf",
+        "regex:/api/public/divers/([a-z0-9-]+)",
+        "regex:/api/users/(user_[A-Za-z0-9]+)",
     }
 
     discovered = discovered_literals | discovered_regex

--- a/backend/tests/test_dive_backend_units.py
+++ b/backend/tests/test_dive_backend_units.py
@@ -7,13 +7,6 @@ from pathlib import Path
 import pytest
 
 from divevault import app as dive_backend
-
-
-def test_normalize_pem_env_handles_blank_and_escaped_newlines():
-    assert dive_backend.normalize_pem_env(None) is None
-    assert dive_backend.normalize_pem_env("  line1\\nline2  ") == "line1\nline2"
-
-
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
@@ -27,13 +20,6 @@ def test_normalize_pem_env_handles_blank_and_escaped_newlines():
 )
 def test_normalize_bearer_token(value, expected):
     assert dive_backend.normalize_bearer_token(value) == expected
-
-
-def test_parse_csv_env_discards_empty_entries():
-    assert dive_backend.parse_csv_env(None) == set()
-    assert dive_backend.parse_csv_env(" one, two ,, three , ") == {"one", "two", "three"}
-
-
 def test_sanitize_profile_license_filename_keeps_pdf_name():
     assert dive_backend.sanitize_profile_license_filename(r"C:\Users\joshu\licenses\advanced-open-water") == "advanced-open-water.pdf"
     assert dive_backend.sanitize_profile_license_filename(" rescue-diver.pdf ") == "rescue-diver.pdf"
@@ -108,45 +94,33 @@ def test_nominatim_client_search_requires_query():
         client.search("   ")
 
 
-def test_build_clerk_verifier_derives_jwks_url_and_issuer():
+def test_build_auth_verifier_uses_first_party_jwt_settings():
     args = argparse.Namespace(
-        clerk_secret_key=None,
-        clerk_jwt_key="public-key",
-        clerk_jwks_url=None,
-        clerk_api_url="https://api.clerk.com",
-        clerk_frontend_api_url="https://clerk.example.com/",
-        clerk_issuer=None,
-        clerk_audience="aud",
-        clerk_authorized_parties="https://app.example.com, https://admin.example.com",
-        clerk_api_key_scopes="sync:write, dives:read",
+        auth_jwt_secret="test-secret",
+        auth_jwt_issuer="divevault.example",
+        auth_jwt_audience="divevault.app",
     )
 
-    verifier = dive_backend.build_clerk_verifier(args, sync_token_manager=None)
+    verifier = dive_backend.build_auth_verifier(args, sync_token_manager=None)
 
     assert verifier is not None
-    assert verifier.jwks_url == "https://clerk.example.com/.well-known/jwks.json"
-    assert verifier.issuer == "https://clerk.example.com"
-    assert verifier.authorized_parties == {"https://app.example.com", "https://admin.example.com"}
-    assert verifier.required_api_key_scopes == {"sync:write", "dives:read"}
+    assert verifier.jwt_secret == "test-secret"
+    assert verifier.issuer == "divevault.example"
+    assert verifier.audience == "divevault.app"
+    assert verifier.configured is True
 
 
-def test_build_clerk_verifier_returns_none_when_unconfigured(caplog):
+def test_build_auth_verifier_reports_unconfigured_when_secret_missing():
     args = argparse.Namespace(
-        clerk_secret_key=None,
-        clerk_jwt_key=None,
-        clerk_jwks_url=None,
-        clerk_api_url="https://api.clerk.com",
-        clerk_frontend_api_url=None,
-        clerk_issuer=None,
-        clerk_audience=None,
-        clerk_authorized_parties=None,
-        clerk_api_key_scopes=None,
+        auth_jwt_secret="",
+        auth_jwt_issuer="divevault.example",
+        auth_jwt_audience="divevault.app",
     )
 
-    verifier = dive_backend.build_clerk_verifier(args, sync_token_manager=None)
+    verifier = dive_backend.build_auth_verifier(args, sync_token_manager=None)
 
-    assert verifier is None
-    assert "Clerk authentication is not configured" in caplog.text
+    assert verifier is not None
+    assert verifier.configured is False
 
 
 def test_resolve_frontend_dir_uses_existing_directory(tmp_path: Path):
@@ -193,13 +167,13 @@ def test_extract_token_prefers_authorization_header():
         "Cookie": "__session=cookie-token",
     }
 
-    assert dive_backend.ClerkTokenVerifier._extract_token(headers) == "auth-token"
+    assert dive_backend.DiveVaultAuthTokenVerifier._extract_token(headers) == "auth-token"
 
 
 def test_extract_token_uses_session_cookie_when_authorization_missing():
     headers = {"Cookie": "theme=dark; __session=cookie-token; csrftoken=abc"}
 
-    assert dive_backend.ClerkTokenVerifier._extract_token(headers) == "cookie-token"
+    assert dive_backend.DiveVaultAuthTokenVerifier._extract_token(headers) == "cookie-token"
 
 
 def test_principal_id_from_claims_accepts_multiple_claim_names():

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,14 +1,13 @@
 {
   "name": "divevault-frontend",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "divevault-frontend",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
-        "@clerk/vue": "^2.0.11",
         "leaflet": "^1.9.4",
         "pdfjs-dist": "^5.6.205",
         "vue": "^3.5.32"
@@ -80,50 +79,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@clerk/shared": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.6.0.tgz",
-      "integrity": "sha512-dtbsO/+xK5e+qWuOAY1ekZ8BJxsB0F0LYDpXWjRON7JSoFKSaqqaH5cwBvdjbbWaehb6jz1YUQmWVV8gBOx6Ag==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.90.16",
-        "dequal": "2.0.3",
-        "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
-        "std-env": "^3.9.0"
-      },
-      "engines": {
-        "node": ">=20.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
-        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@clerk/vue": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@clerk/vue/-/vue-2.0.11.tgz",
-      "integrity": "sha512-06OyPfQfjbf4MpnbLAVVx7rgoTzp4VddF6QK4hKUpK9jhv657aojsOJYVhxHQzAO2x0ubei0az6kf2/t8MHB1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^4.6.0"
-      },
-      "engines": {
-        "node": ">=20.9.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.2.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -597,9 +552,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -617,9 +569,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -637,9 +586,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -657,9 +603,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -677,9 +620,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -697,9 +637,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1121,16 +1058,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.90.16",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
-      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1370,15 +1297,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1485,12 +1403,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1506,15 +1418,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/leaflet": {
@@ -1988,12 +1891,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,6 @@
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@clerk/vue": "^2.0.11",
     "leaflet": "^1.9.4",
     "pdfjs-dist": "^5.6.205",
     "vue": "^3.5.32"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "divevault-frontend",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -104,6 +104,16 @@ export default {
       activeSettingsSection: DEFAULT_SETTINGS_SECTION,
       settingsMenuExpanded: false,
       mobileAccountMenuOpen: false,
+      desktopAccountMenuOpen: false,
+      passwordDialogOpen: false,
+      passwordForm: {
+        currentPassword: "",
+        newPassword: "",
+        confirmPassword: ""
+      },
+      passwordSubmitting: false,
+      passwordError: "",
+      passwordStatus: "",
       filledIconStyle,
       navItems: [
         { id: "dashboard", label: "Dashboard", mobileLabel: "Dashboard", icon: "dashboard", mobileIcon: "dashboard", eyebrow: "Dive Overview", title: "Logbook" },
@@ -219,8 +229,11 @@ export default {
     isPublicRoute() {
       return Boolean(this.publicRouteSlug);
     },
+    canManageUsers() {
+      return Boolean(this.authUser?.isOwner);
+    },
     settingsSubnavItems() {
-      return SETTINGS_SECTIONS;
+      return SETTINGS_SECTIONS.filter((section) => section.id !== "manage-users" || this.canManageUsers);
     },
     loadingViewKey() {
       if (this.activeView === "edit") return "edit";
@@ -245,7 +258,13 @@ export default {
       }
     },
     normalizeSettingsSection(sectionId) {
-      return SETTINGS_SECTION_IDS.has(sectionId) ? sectionId : DEFAULT_SETTINGS_SECTION;
+      if (!SETTINGS_SECTION_IDS.has(sectionId)) {
+        return DEFAULT_SETTINGS_SECTION;
+      }
+      if (sectionId === "manage-users" && !this.canManageUsers) {
+        return DEFAULT_SETTINGS_SECTION;
+      }
+      return sectionId;
     },
     settingsHash(sectionId = this.activeSettingsSection) {
       return `settings/${this.normalizeSettingsSection(sectionId)}`;
@@ -273,6 +292,15 @@ export default {
       this.loading = false;
       this.error = "";
       this.backendHealthy = false;
+      this.passwordDialogOpen = false;
+      this.passwordForm = {
+        currentPassword: "",
+        newPassword: "",
+        confirmPassword: ""
+      };
+      this.passwordSubmitting = false;
+      this.passwordError = "";
+      this.passwordStatus = "";
       this.dashboardStats = {
         totalDives: 0,
         totalSeconds: 0,
@@ -285,6 +313,7 @@ export default {
       };
       this.activeSettingsSection = DEFAULT_SETTINGS_SECTION;
       this.settingsMenuExpanded = false;
+      this.desktopAccountMenuOpen = false;
       this.lastAuthenticatedSessionId = null;
     },
     async syncAuthState() {
@@ -377,17 +406,96 @@ export default {
     },
     closeMobileAccountMenu() {
       this.mobileAccountMenuOpen = false;
+      this.desktopAccountMenuOpen = false;
+    },
+    toggleDesktopAccountMenu() {
+      this.desktopAccountMenuOpen = !this.desktopAccountMenuOpen;
+    },
+    closeDesktopAccountMenu() {
+      this.desktopAccountMenuOpen = false;
     },
     async openMobileSettings() {
       this.closeMobileAccountMenu();
+      this.closeDesktopAccountMenu();
       await this.setView("settings");
     },
     async signOutUser() {
       this.closeMobileAccountMenu();
+      this.closeDesktopAccountMenu();
       if (typeof this.authSignOut !== "function") {
         return;
       }
       await this.authSignOut({ redirectUrl: "/" });
+    },
+    openPasswordDialog() {
+      this.closeMobileAccountMenu();
+      this.closeDesktopAccountMenu();
+      this.passwordDialogOpen = true;
+      this.passwordError = "";
+      this.passwordStatus = "";
+      this.passwordForm = {
+        currentPassword: "",
+        newPassword: "",
+        confirmPassword: ""
+      };
+    },
+    closePasswordDialog() {
+      this.passwordDialogOpen = false;
+      this.passwordSubmitting = false;
+      this.passwordError = "";
+      this.passwordStatus = "";
+      this.passwordForm = {
+        currentPassword: "",
+        newPassword: "",
+        confirmPassword: ""
+      };
+    },
+    async submitPasswordChange() {
+      this.passwordSubmitting = true;
+      this.passwordError = "";
+      this.passwordStatus = "";
+      const currentPassword = this.passwordForm.currentPassword;
+      const newPassword = this.passwordForm.newPassword;
+      const confirmPassword = this.passwordForm.confirmPassword;
+      if (!currentPassword || !newPassword) {
+        this.passwordError = "Current password and new password are required.";
+        this.passwordSubmitting = false;
+        return;
+      }
+      if (newPassword.length < 8) {
+        this.passwordError = "New password must be at least 8 characters.";
+        this.passwordSubmitting = false;
+        return;
+      }
+      if (newPassword !== confirmPassword) {
+        this.passwordError = "New password confirmation does not match.";
+        this.passwordSubmitting = false;
+        return;
+      }
+      try {
+        const response = await this.authenticatedFetch("/api/auth/password", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            current_password: currentPassword,
+            new_password: newPassword
+          })
+        });
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(payload?.error || `API returned ${response.status}`);
+        }
+        this.passwordStatus = "Password updated.";
+        window.setTimeout(() => {
+          if (this.passwordDialogOpen) {
+            this.closePasswordDialog();
+          }
+        }, 900);
+      } catch (error) {
+        this.passwordError = error?.message || "Could not update the password.";
+      } finally {
+        this.passwordSubmitting = false;
+      }
     },
     isDisabledNavItem(view) {
       return Boolean(this.navItems.find((item) => item.id === view)?.disabled);
@@ -1177,6 +1285,9 @@ export default {
                 <button @click="openMobileSettings()" class="inline-flex items-center justify-center rounded-xl bg-surface-container-high px-3 py-2 font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary transition-colors hover:bg-surface-container-highest">
                   Open Settings
                 </button>
+                <button @click="openPasswordDialog" class="inline-flex items-center justify-center rounded-xl bg-surface-container-high px-3 py-2 font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary transition-colors hover:bg-surface-container-highest">
+                  Change Password
+                </button>
                 <button @click="signOutUser" class="inline-flex items-center justify-center rounded-xl border border-primary/15 px-3 py-2 font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary transition-colors hover:bg-surface-container-high">
                   Sign Out
                 </button>
@@ -1186,17 +1297,28 @@ export default {
         </div>
         <div class="hidden h-full items-center justify-between px-8 md:flex">
           <h2 class="font-headline text-2xl font-bold tracking-[0.08em] text-primary">DiveVault</h2>
-          <div class="flex items-center gap-3 rounded-2xl border border-primary/10 bg-surface-container-high/70 px-3 py-2 text-on-surface">
-            <div class="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/12 text-[11px] font-bold uppercase tracking-[0.14em] text-primary">
+          <div class="relative flex items-center gap-3 rounded-2xl border border-primary/10 bg-surface-container-high/70 px-3 py-2 text-on-surface">
+            <button @click="toggleDesktopAccountMenu" class="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/12 text-[11px] font-bold uppercase tracking-[0.14em] text-primary transition-colors hover:bg-primary/18">
               {{ currentUserInitials }}
-            </div>
+            </button>
             <div class="min-w-0">
               <p class="max-w-[12rem] truncate text-sm font-semibold text-on-surface">{{ currentUserName }}</p>
               <p class="max-w-[12rem] truncate text-xs text-secondary">{{ currentUserEmail }}</p>
             </div>
-            <button @click="signOutUser" class="inline-flex items-center justify-center rounded-xl border border-primary/15 px-3 py-2 font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary transition-colors hover:bg-surface-container-high">
-              Sign Out
-            </button>
+            <div v-if="desktopAccountMenuOpen" class="absolute right-0 top-[calc(100%+0.75rem)] z-40 w-56 rounded-2xl border border-primary/10 bg-surface-container-low p-3 shadow-panel">
+              <div class="border-b border-primary/10 pb-3">
+                <p class="truncate text-sm font-semibold text-on-surface">{{ currentUserName }}</p>
+                <p class="mt-1 truncate text-xs text-secondary">{{ currentUserEmail }}</p>
+              </div>
+              <div class="mt-3 flex flex-col gap-2">
+                <button @click="openPasswordDialog" class="inline-flex items-center justify-center rounded-xl bg-surface-container-high px-3 py-2 font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary transition-colors hover:bg-surface-container-highest">
+                  Change Password
+                </button>
+                <button @click="signOutUser" class="inline-flex items-center justify-center rounded-xl border border-primary/15 px-3 py-2 font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary transition-colors hover:bg-surface-container-high">
+                  Sign Out
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </header>
@@ -1308,6 +1430,51 @@ export default {
           <span class="font-label text-[10px] font-bold">{{ item.mobileLabel }}</span>
         </button>
       </nav>
+      <div
+        v-if="passwordDialogOpen"
+        @click.self="closePasswordDialog"
+        class="fixed inset-0 z-[60] flex items-center justify-center bg-background/88 px-6 py-8 backdrop-blur-sm"
+      >
+        <div class="w-full max-w-md rounded-3xl border border-primary/10 bg-surface-container-low p-6 shadow-panel">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <p class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-primary">Account Security</p>
+              <h3 class="mt-3 font-headline text-2xl font-bold tracking-tight text-on-surface">Change Password</h3>
+              <p class="mt-3 text-sm leading-6 text-secondary">Update the password for your current DiveVault account.</p>
+            </div>
+            <button @click="closePasswordDialog" :disabled="passwordSubmitting" class="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-primary/10 text-secondary transition-colors hover:bg-surface-container-high">
+              <span class="material-symbols-outlined text-lg">close</span>
+            </button>
+          </div>
+
+          <p v-if="passwordStatus" class="mt-5 text-sm text-primary">{{ passwordStatus }}</p>
+          <p v-if="passwordError" class="mt-5 text-sm text-error">{{ passwordError }}</p>
+
+          <div class="mt-5 space-y-4">
+            <label class="space-y-2">
+              <span class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Current Password</span>
+              <input v-model="passwordForm.currentPassword" type="password" class="w-full rounded-2xl border border-primary/15 bg-background/20 px-4 py-3 text-sm text-on-surface outline-none transition-colors focus:border-primary/40" />
+            </label>
+            <label class="space-y-2">
+              <span class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">New Password</span>
+              <input v-model="passwordForm.newPassword" type="password" class="w-full rounded-2xl border border-primary/15 bg-background/20 px-4 py-3 text-sm text-on-surface outline-none transition-colors focus:border-primary/40" />
+            </label>
+            <label class="space-y-2">
+              <span class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Confirm New Password</span>
+              <input v-model="passwordForm.confirmPassword" type="password" class="w-full rounded-2xl border border-primary/15 bg-background/20 px-4 py-3 text-sm text-on-surface outline-none transition-colors focus:border-primary/40" />
+            </label>
+          </div>
+
+          <div class="mt-6 flex flex-wrap gap-3">
+            <button @click="submitPasswordChange" :disabled="passwordSubmitting" class="inline-flex items-center justify-center rounded-xl bg-primary px-4 py-3 font-label text-[10px] font-bold uppercase tracking-[0.16em] text-on-primary transition-all hover:brightness-110">
+              {{ passwordSubmitting ? 'Updating Password' : 'Update Password' }}
+            </button>
+            <button @click="closePasswordDialog" :disabled="passwordSubmitting" class="inline-flex items-center justify-center rounded-xl border border-primary/15 px-4 py-3 font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary transition-colors hover:bg-surface-container-high">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   `
 };

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -52,12 +52,12 @@ export default {
     const { user } = useUser();
 
     return {
-      clerkGetToken: getToken,
-      clerkLoaded: isLoaded,
-      clerkSessionId: sessionId,
-      clerkSignOut: signOut,
-      clerkSignedIn: isSignedIn,
-      clerkUser: user
+      authGetToken: getToken,
+      authLoaded: isLoaded,
+      authSessionId: sessionId,
+      authSignOut: signOut,
+      authSignedIn: isSignedIn,
+      authUser: user
     };
   },
   data() {
@@ -114,22 +114,22 @@ export default {
     };
   },
   watch: {
-    clerkLoaded: {
+    authLoaded: {
       handler() {
         this.syncAuthState();
       },
       immediate: true
     },
-    clerkSignedIn: {
+    authSignedIn: {
       handler() {
         this.syncAuthState();
       },
       immediate: true
     },
-    clerkSessionId() {
+    authSessionId() {
       this.syncAuthState();
     },
-    clerkUser: {
+    authUser: {
       handler() {
         this.sessionEmail = this.currentUserEmail;
       },
@@ -139,13 +139,13 @@ export default {
   },
   computed: {
     currentUserEmail() {
-      return this.clerkUser?.primaryEmailAddress?.emailAddress
-        || this.clerkUser?.emailAddresses?.[0]?.emailAddress
+      return this.authUser?.primaryEmailAddress?.emailAddress
+        || this.authUser?.emailAddresses?.[0]?.emailAddress
         || "";
     },
     currentUserName() {
-      const firstName = this.clerkUser?.firstName?.trim() || "";
-      const lastName = this.clerkUser?.lastName?.trim() || "";
+      const firstName = this.authUser?.firstName?.trim() || "";
+      const lastName = this.authUser?.lastName?.trim() || "";
       return [firstName, lastName].filter(Boolean).join(" ") || this.currentUserEmail || "Diver";
     },
     currentUserInitials() {
@@ -293,24 +293,24 @@ export default {
         return;
       }
 
-      if (!this.clerkLoaded) {
+      if (!this.authLoaded) {
         this.loading = true;
         return;
       }
 
-      this.isAuthenticated = Boolean(this.clerkSignedIn);
+      this.isAuthenticated = Boolean(this.authSignedIn);
       this.sessionEmail = this.currentUserEmail;
 
-      if (!this.isAuthenticated || !this.clerkSessionId) {
+      if (!this.isAuthenticated || !this.authSessionId) {
         this.resetAuthenticatedState();
         return;
       }
 
-      if (this.lastAuthenticatedSessionId === this.clerkSessionId) {
+      if (this.lastAuthenticatedSessionId === this.authSessionId) {
         return;
       }
 
-      this.lastAuthenticatedSessionId = this.clerkSessionId;
+      this.lastAuthenticatedSessionId = this.authSessionId;
       this.syncViewFromHash();
       await Promise.all([this.fetchDives(), this.fetchProfileData()]);
     },
@@ -338,11 +338,11 @@ export default {
       const requireAuth = requestOptions.requireAuth !== false;
 
       let token = null;
-      if (requireAuth && typeof this.clerkGetToken === "function") {
+      if (requireAuth && typeof this.authGetToken === "function") {
         token = await this.withTimeout(
-          this.clerkGetToken(),
+          this.authGetToken(),
           timeoutMs,
-          "Timed out while waiting for the Clerk session token."
+          "Timed out while waiting for the Authentication session token."
         );
       }
 
@@ -384,10 +384,10 @@ export default {
     },
     async signOutUser() {
       this.closeMobileAccountMenu();
-      if (typeof this.clerkSignOut !== "function") {
+      if (typeof this.authSignOut !== "function") {
         return;
       }
-      await this.clerkSignOut({ redirectUrl: "/" });
+      await this.authSignOut({ redirectUrl: "/" });
     },
     isDisabledNavItem(view) {
       return Boolean(this.navItems.find((item) => item.id === view)?.disabled);
@@ -1105,7 +1105,7 @@ export default {
   },
   template: `
     <public-profile-view v-if="isPublicRoute" :slug="publicRouteSlug"></public-profile-view>
-    <div v-else-if="!clerkLoaded" class="flex min-h-screen items-center justify-center bg-background px-6 text-on-background">
+    <div v-else-if="!authLoaded" class="flex min-h-screen items-center justify-center bg-background px-6 text-on-background">
       <section class="bg-surface-container-low p-10 shadow-panel">
         <p class="font-headline text-2xl font-bold">Loading secure access...</p>
       </section>

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -16,6 +16,7 @@ function applySession(token, mePayload) {
       firstName: mePayload.first_name || "",
       lastName: mePayload.last_name || "",
       role: mePayload.role || "user",
+      isOwner: Boolean(mePayload.is_owner),
       primaryEmailAddress: { emailAddress: mePayload.email || "" },
       emailAddresses: [{ emailAddress: mePayload.email || "" }]
     }

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -1,237 +1,107 @@
-import {
-  SignIn as ClerkSignIn,
-  Waitlist as ClerkWaitlist,
-  clerkPlugin,
-  useAuth as useClerkAuth,
-  useSignIn as useClerkSignIn,
-  useUser as useClerkUser
-} from "@clerk/vue";
 import { computed, reactive } from "vue";
 
-const TEST_AUTH_KEY = "__DIVEVAULT_TEST_STATE__";
+const TOKEN_STORAGE_KEY = "divevault_auth_token";
+const state = reactive({
+  loaded: false,
+  token: null,
+  user: null,
+  sessionId: null
+});
 
-function defaultTestUser() {
-  return {
-    firstName: "Test",
-    lastName: "Diver",
-    primaryEmailAddress: {
-      emailAddress: "diver@example.com"
-    },
-    emailAddresses: [
-      {
-        emailAddress: "diver@example.com"
-      }
-    ]
-  };
-}
-
-function normalizeTestUser(user) {
-  const base = defaultTestUser();
-  const normalized = {
-    ...base,
-    ...(user || {})
-  };
-  const primaryEmail = normalized?.primaryEmailAddress?.emailAddress
-    || normalized?.emailAddresses?.[0]?.emailAddress
-    || base.primaryEmailAddress.emailAddress;
-
-  normalized.primaryEmailAddress = {
-    emailAddress: primaryEmail
-  };
-  normalized.emailAddresses = Array.isArray(normalized.emailAddresses) && normalized.emailAddresses.length
-    ? normalized.emailAddresses.map((entry) => ({
-      emailAddress: entry?.emailAddress || primaryEmail
-    }))
-    : [{ emailAddress: primaryEmail }];
-
-  return normalized;
-}
-
-function rawTestAuthState() {
-  if (typeof window === "undefined") return null;
-  const state = window[TEST_AUTH_KEY];
-  return state && typeof state === "object" ? state : null;
-}
-
-function hasTestAuthState() {
-  return Boolean(rawTestAuthState());
-}
-
-function ensureTestAuthState() {
-  const providedState = rawTestAuthState();
-  if (!providedState) return null;
-
-  if (!providedState.__authState) {
-    const signedIn = providedState.signedIn !== false;
-    providedState.__authState = reactive({
-      signedIn,
-      sessionId: providedState.sessionId || (signedIn ? "playwright-session" : null),
-      token: providedState.token || "playwright-token",
-      user: normalizeTestUser(providedState.user),
-      waitlistJoined: false,
-      recoveryEmail: ""
-    });
-  }
-
-  return providedState.__authState;
-}
-
-function installAuthPlugin(app, options) {
-  if (hasTestAuthState()) {
-    return app;
-  }
-  return app.use(clerkPlugin, options);
-}
-
-async function signOutTestUser(redirectUrl = "/") {
-  const state = ensureTestAuthState();
-  if (!state) return;
-  state.signedIn = false;
-  state.sessionId = null;
-  if (typeof window !== "undefined") {
-    window.location.hash = "";
-    if (redirectUrl && window.location.pathname !== redirectUrl) {
-      window.history.replaceState(null, "", redirectUrl);
+function applySession(token, mePayload) {
+  state.token = token || null;
+  state.user = mePayload
+    ? {
+      id: mePayload.user_id,
+      firstName: mePayload.first_name || "",
+      lastName: mePayload.last_name || "",
+      role: mePayload.role || "user",
+      primaryEmailAddress: { emailAddress: mePayload.email || "" },
+      emailAddresses: [{ emailAddress: mePayload.email || "" }]
     }
+    : null;
+  state.sessionId = mePayload?.session_id || null;
+}
+
+async function loadUserFromToken(token) {
+  const response = await fetch("/api/auth/me", {
+    headers: { Authorization: `Bearer ${token}` },
+    credentials: "include"
+  });
+  if (!response.ok) {
+    throw new Error("Session expired");
   }
+  return response.json();
+}
+
+async function initializeAuth() {
+  if (state.loaded) return;
+  const token = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+  if (!token) {
+    state.loaded = true;
+    return;
+  }
+  try {
+    const mePayload = await loadUserFromToken(token);
+    applySession(token, mePayload);
+  } catch {
+    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+    applySession(null, null);
+  } finally {
+    state.loaded = true;
+  }
+}
+
+async function loginWithPassword(email, password) {
+  const response = await fetch("/api/auth/login", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password })
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload?.error || "Unable to sign in");
+  }
+  const token = payload?.token;
+  const mePayload = await loadUserFromToken(token);
+  window.localStorage.setItem(TOKEN_STORAGE_KEY, token);
+  applySession(token, mePayload);
+  return mePayload;
+}
+
+async function registerUser(input) {
+  const response = await fetch("/api/auth/register", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input)
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload?.error || "Unable to register account");
+  }
+  return payload;
 }
 
 function useAuth() {
-  const state = ensureTestAuthState();
-  if (!state) {
-    return useClerkAuth();
-  }
-
   return {
     getToken: async () => state.token,
-    isLoaded: computed(() => true),
-    isSignedIn: computed(() => state.signedIn),
+    isLoaded: computed(() => state.loaded),
+    isSignedIn: computed(() => Boolean(state.token && state.user)),
     sessionId: computed(() => state.sessionId),
-    signOut: async (options = {}) => signOutTestUser(options.redirectUrl)
+    signOut: async () => {
+      window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+      applySession(null, null);
+      window.location.hash = "";
+    }
   };
 }
 
 function useUser() {
-  const state = ensureTestAuthState();
-  if (!state) {
-    return useClerkUser();
-  }
-
   return {
-    user: computed(() => (state.signedIn ? state.user : null))
+    user: computed(() => state.user)
   };
 }
 
-function testSignInApi(state) {
-  return {
-    async create(options = {}) {
-      state.recoveryEmail = options.identifier || state.user.primaryEmailAddress.emailAddress;
-      return { status: "needs_first_factor" };
-    },
-    async attemptFirstFactor() {
-      state.signedIn = true;
-      state.sessionId = state.sessionId || "playwright-session";
-      return {
-        status: "complete",
-        createdSessionId: state.sessionId
-      };
-    },
-    async resetPassword() {
-      state.signedIn = true;
-      state.sessionId = state.sessionId || "playwright-session";
-      return {
-        status: "complete",
-        createdSessionId: state.sessionId
-      };
-    }
-  };
-}
-
-function useSignIn() {
-  const state = ensureTestAuthState();
-  if (!state) {
-    return useClerkSignIn();
-  }
-
-  return {
-    isLoaded: computed(() => true),
-    signIn: testSignInApi(state),
-    setActive: async ({ session } = {}) => {
-      state.signedIn = true;
-      state.sessionId = session || state.sessionId || "playwright-session";
-      return { sessionId: state.sessionId };
-    }
-  };
-}
-
-const TestSignIn = {
-  name: "TestSignInStub",
-  methods: {
-    async signIn() {
-      const state = ensureTestAuthState();
-      if (!state) return;
-      state.signedIn = true;
-      state.sessionId = state.sessionId || "playwright-session";
-      window.location.hash = "";
-    }
-  },
-  template: `
-    <div class="space-y-4 rounded-[1.1rem] border border-primary/10 bg-surface-container-high/35 p-5 text-left shadow-panel">
-      <p class="font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary">Clerk Test Mode</p>
-      <p class="text-sm leading-6 text-on-surface-variant">Browser tests run against a local auth stub instead of the hosted Clerk widget.</p>
-      <button
-        type="button"
-        @click="signIn"
-        class="w-full rounded-[1.1rem] bg-[linear-gradient(135deg,#71c8ff_0%,#5faeff_45%,#5997ef_100%)] px-4 py-4 font-label text-[0.95rem] font-black tracking-[0.08em] text-[#031726] shadow-[0_14px_28px_rgba(43,116,181,0.22)]"
-      >
-        Sign In Test Diver
-      </button>
-    </div>
-  `
-};
-
-const TestWaitlist = {
-  name: "TestWaitlistStub",
-  data() {
-    return {
-      waitlistJoined: false
-    };
-  },
-  methods: {
-    joinWaitlist() {
-      const state = ensureTestAuthState();
-      if (!state) return;
-      state.waitlistJoined = true;
-      this.waitlistJoined = true;
-    }
-  },
-  template: `
-    <div class="space-y-4 rounded-[1.1rem] border border-primary/10 bg-surface-container-high/35 p-5 text-left shadow-panel">
-      <p class="font-label text-[10px] font-bold uppercase tracking-[0.16em] text-primary">Waitlist Test Mode</p>
-      <p class="text-sm leading-6 text-on-surface-variant">The production waitlist is replaced with a local stub while Playwright is running.</p>
-      <button
-        type="button"
-        @click="joinWaitlist"
-        class="w-full rounded-[1.1rem] border border-primary/15 px-4 py-4 font-label text-[0.95rem] font-black tracking-[0.08em] text-primary"
-      >
-        Join Local Waitlist
-      </button>
-      <p v-if="waitlistJoined" class="text-sm text-primary">
-        Waitlist request recorded locally.
-      </p>
-    </div>
-  `
-};
-
-const SignIn = hasTestAuthState() ? TestSignIn : ClerkSignIn;
-const Waitlist = hasTestAuthState() ? TestWaitlist : ClerkWaitlist;
-
-export {
-  SignIn,
-  Waitlist,
-  hasTestAuthState,
-  installAuthPlugin,
-  useAuth,
-  useSignIn,
-  useUser
-};
+export { initializeAuth, loginWithPassword, registerUser, useAuth, useUser };

--- a/frontend/src/components/login.js
+++ b/frontend/src/components/login.js
@@ -1,476 +1,132 @@
-import { SignIn, Waitlist, useSignIn } from "../auth.js";
+import { loginWithPassword, registerUser } from "../auth.js";
 
-const AUTH_VIEW_ENTRY = "entry";
 const AUTH_VIEW_SIGNIN = "signin";
+const AUTH_VIEW_REGISTER = "register";
 const AUTH_VIEW_RECOVER = "recover";
-const AUTH_VIEW_WAITLIST = "waitlist";
-const AUTH_VIEWS = new Set([AUTH_VIEW_ENTRY, AUTH_VIEW_SIGNIN, AUTH_VIEW_RECOVER, AUTH_VIEW_WAITLIST]);
-
-const CLERK_APPEARANCE = {
-  variables: {
-    colorPrimary: "#7fd3ff",
-    colorBackground: "rgba(19, 44, 64, 0.18)",
-    colorInputBackground: "rgba(9, 31, 48, 0.72)",
-    colorInputText: "#eaf7ff",
-    colorText: "#eaf7ff",
-    colorTextSecondary: "rgba(211, 232, 247, 0.74)",
-    colorNeutral: "rgba(146, 185, 215, 0.42)",
-    colorDanger: "#ff978d",
-    borderRadius: "1rem",
-    fontFamily: "\"Space Grotesk\", sans-serif"
-  },
-  elements: {
-    rootBox: {
-      width: "100%"
-    },
-    cardBox: {
-      width: "100%",
-      boxShadow: "none",
-      background: "transparent"
-    },
-    card: {
-      boxShadow: "none",
-      background: "transparent",
-      border: "1px solid rgba(127, 211, 255, 0.08)",
-      borderRadius: "1.25rem",
-      padding: "0"
-    },
-    headerTitle: {
-      display: "none"
-    },
-    headerSubtitle: {
-      display: "none"
-    },
-    formFieldLabel: {
-      color: "rgba(212, 237, 255, 0.72)",
-      letterSpacing: "0.16em",
-      fontSize: "10px",
-      fontWeight: "700"
-    },
-    formFieldInput: {
-      minHeight: "46px",
-      background: "rgba(12, 34, 54, 0.58)",
-      border: "1px solid rgba(127, 211, 255, 0.08)",
-      color: "#eaf7ff",
-      boxShadow: "none"
-    },
-    formFieldInputShowPasswordButton: {
-      color: "rgba(212, 237, 255, 0.72)"
-    },
-    formButtonPrimary: {
-      minHeight: "46px",
-      background: "linear-gradient(135deg, rgba(113, 208, 255, 0.88), rgba(83, 165, 255, 0.82))",
-      color: "#02101f",
-      fontWeight: "800",
-      letterSpacing: "0.04em",
-      boxShadow: "0 10px 22px rgba(11, 59, 103, 0.18)"
-    },
-    footerAction: {
-      display: "none"
-    },
-    footerActionLink: {
-      color: "#7fd3ff",
-      fontWeight: "700",
-      letterSpacing: "0.04em"
-    },
-    formResendCodeLink: {
-      color: "#7fd3ff",
-      fontWeight: "700"
-    },
-    socialButtonsBlockButton: {
-      background: "rgba(16, 44, 69, 0.52)",
-      border: "1px solid rgba(127, 211, 255, 0.1)",
-      color: "#eaf7ff",
-      boxShadow: "none"
-    },
-    socialButtonsBlockButtonText: {
-      color: "#eaf7ff",
-      fontWeight: "600",
-      letterSpacing: "0.04em"
-    },
-    dividerLine: {
-      background: "rgba(127, 211, 255, 0.08)"
-    },
-    dividerText: {
-      color: "rgba(212, 237, 255, 0.62)",
-      letterSpacing: "0.18em",
-      fontSize: "10px"
-    },
-    identityPreviewText: {
-      color: "#eaf7ff"
-    },
-    identityPreviewEditButton: {
-      color: "#7fd3ff"
-    },
-    alert: {
-      background: "rgba(255, 138, 128, 0.08)",
-      border: "1px solid rgba(255, 138, 128, 0.18)"
-    },
-    alertText: {
-      color: "#ffd7d2"
-    }
-  }
-};
 
 export default {
   name: "LoginView",
-  components: {
-    SignIn,
-    Waitlist
-  },
-  setup() {
-    const { isLoaded, signIn, setActive } = useSignIn();
-
-    return {
-      clerkSignInLoaded: isLoaded,
-      clerkSignIn: signIn,
-      clerkSetActive: setActive
-    };
-  },
   data() {
     return {
       authView: AUTH_VIEW_SIGNIN,
-      clerkAppearance: CLERK_APPEARANCE,
-      recoveryEmail: "",
+      email: "",
+      password: "",
+      firstName: "",
+      lastName: "",
+      loading: false,
+      error: "",
+      message: "",
       recoveryCode: "",
-      recoveryPassword: "",
-      recoveryPasswordConfirm: "",
-      recoveryStep: "email",
-      recoveryLoading: false,
-      recoveryError: "",
-      recoveryMessage: ""
+      recoveryPassword: ""
     };
   },
-  computed: {
-    authTitle() {
-      if (this.authView === AUTH_VIEW_RECOVER) {
-        return "Recover Access";
-      }
-      if (this.authView === AUTH_VIEW_WAITLIST) {
-        return "Join Waitlist";
-      }
-      return "Login";
-    },
-    isRecoveryCodeStep() {
-      return this.recoveryStep === "code";
-    }
-  },
-  mounted() {
-    this.syncAuthViewFromHash();
-    window.addEventListener("hashchange", this.syncAuthViewFromHash);
-  },
-  beforeUnmount() {
-    window.removeEventListener("hashchange", this.syncAuthViewFromHash);
-  },
   methods: {
-    syncAuthViewFromHash() {
-      const rawHash = window.location.hash.replace(/^#/, "").trim().toLowerCase();
-      this.authView = AUTH_VIEWS.has(rawHash) ? rawHash : AUTH_VIEW_SIGNIN;
-    },
-    setAuthView(view) {
-      const nextView = AUTH_VIEWS.has(view) ? view : AUTH_VIEW_SIGNIN;
-      window.location.hash = nextView === AUTH_VIEW_SIGNIN ? "" : nextView;
-      this.authView = nextView;
-    },
-    openRecovery() {
-      this.recoveryCode = "";
-      this.recoveryPassword = "";
-      this.recoveryPasswordConfirm = "";
-      this.recoveryStep = "email";
-      this.recoveryError = "";
-      this.recoveryMessage = "";
-      this.setAuthView(AUTH_VIEW_RECOVER);
-    },
-    formatClerkError(error) {
-      const errors = Array.isArray(error?.errors) ? error.errors : [];
-      if (errors.length) {
-        return errors
-          .map((entry) => entry?.longMessage || entry?.message || entry?.code)
-          .filter(Boolean)
-          .join(" ");
-      }
-      if (typeof error?.message === "string" && error.message.trim()) {
-        return error.message.trim();
-      }
-      return "Clerk could not complete that request.";
-    },
-    async startPasswordRecovery() {
-      const email = this.recoveryEmail.trim();
-      if (!email) {
-        this.recoveryError = "Enter the email address linked to your DiveVault account.";
-        return;
-      }
-      if (!this.clerkSignInLoaded || !this.clerkSignIn) {
-        this.recoveryError = "Clerk is still loading. Try again in a moment.";
-        return;
-      }
-
-      this.recoveryLoading = true;
-      this.recoveryError = "";
-      this.recoveryMessage = "";
-
+    async submitSignIn() {
+      this.loading = true;
+      this.error = "";
       try {
-        await this.clerkSignIn.create({
-          strategy: "reset_password_email_code",
-          identifier: email
-        });
-        this.recoveryStep = "code";
-        this.recoveryMessage = `Recovery code sent to ${email}.`;
+        await loginWithPassword(this.email.trim(), this.password);
       } catch (error) {
-        this.recoveryError = this.formatClerkError(error);
+        this.error = error?.message || "Login failed.";
       } finally {
-        this.recoveryLoading = false;
+        this.loading = false;
       }
     },
-    async completePasswordRecovery() {
-      if (!this.clerkSignInLoaded || !this.clerkSignIn || !this.clerkSetActive) {
-        this.recoveryError = "Clerk is still loading. Try again in a moment.";
-        return;
-      }
-      if (!this.recoveryCode.trim()) {
-        this.recoveryError = "Enter the recovery code from Clerk.";
-        return;
-      }
-      if (!this.recoveryPassword) {
-        this.recoveryError = "Enter a new password.";
-        return;
-      }
-      if (this.recoveryPassword !== this.recoveryPasswordConfirm) {
-        this.recoveryError = "The new password and confirmation must match.";
-        return;
-      }
-
-      this.recoveryLoading = true;
-      this.recoveryError = "";
-      this.recoveryMessage = "";
-
+    async submitRegister() {
+      this.loading = true;
+      this.error = "";
+      this.message = "";
       try {
-        let result = await this.clerkSignIn.attemptFirstFactor({
-          strategy: "reset_password_email_code",
-          code: this.recoveryCode.trim(),
-          password: this.recoveryPassword
+        await registerUser({
+          email: this.email.trim(),
+          password: this.password,
+          first_name: this.firstName.trim(),
+          last_name: this.lastName.trim()
         });
-
-        if (result.status === "needs_new_password") {
-          result = await this.clerkSignIn.resetPassword({
-            password: this.recoveryPassword
-          });
-        }
-
-        if (result.status === "complete" && result.createdSessionId) {
-          window.location.hash = "";
-          await this.clerkSetActive({ session: result.createdSessionId });
-          return;
-        }
-
-        this.recoveryMessage = "Password updated. Complete any remaining Clerk verification steps to sign in.";
+        this.authView = AUTH_VIEW_SIGNIN;
+        this.message = "Account created. Sign in with your new credentials.";
       } catch (error) {
-        this.recoveryError = this.formatClerkError(error);
+        this.error = error?.message || "Registration failed.";
       } finally {
-        this.recoveryLoading = false;
+        this.loading = false;
+      }
+    },
+    async sendRecoveryCode() {
+      this.loading = true;
+      this.error = "";
+      this.message = "";
+      try {
+        const response = await fetch("/api/auth/recover/start", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: this.email.trim() })
+        });
+        const payload = await response.json();
+        if (!response.ok) {
+          throw new Error(payload?.error || "Unable to start recovery");
+        }
+        this.message = `Recovery code generated: ${payload.recovery_code}`;
+      } catch (error) {
+        this.error = error?.message || "Unable to start recovery.";
+      } finally {
+        this.loading = false;
+      }
+    },
+    async completeRecovery() {
+      this.loading = true;
+      this.error = "";
+      this.message = "";
+      try {
+        const response = await fetch("/api/auth/recover/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: this.email.trim(), code: this.recoveryCode.trim(), password: this.recoveryPassword })
+        });
+        const payload = await response.json();
+        if (!response.ok) {
+          throw new Error(payload?.error || "Unable to reset password");
+        }
+        this.authView = AUTH_VIEW_SIGNIN;
+        this.message = "Password reset complete. Sign in with your new password.";
+      } catch (error) {
+        this.error = error?.message || "Recovery failed.";
+      } finally {
+        this.loading = false;
       }
     }
   },
   template: `
-    <div class="abyssal-auth-shell relative min-h-screen overflow-hidden bg-surface text-on-surface">
-      <div class="pointer-events-none absolute inset-0 opacity-60">
-        <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(6,33,53,0.5),transparent_34rem)]"></div>
-        <div class="absolute inset-0 technical-grid opacity-[0.05]"></div>
-      </div>
+    <div class="min-h-screen flex items-center justify-center bg-surface px-4">
+      <div class="w-full max-w-md rounded-2xl border border-primary/20 bg-surface-container-high/40 p-6 space-y-4">
+        <h1 class="text-2xl font-semibold text-on-surface">DiveVault Authentication</h1>
+        <p v-if="message" class="text-sm text-primary">{{ message }}</p>
+        <p v-if="error" class="text-sm text-red-300">{{ error }}</p>
 
-      <div class="relative flex min-h-screen flex-col">
-        <div class="flex flex-1 flex-col justify-center py-10 md:py-12">
-          <header class="px-6 pb-4 md:px-8 md:pb-5">
-            <div class="mx-auto flex max-w-5xl flex-col items-center text-center">
-              <div class="flex items-center justify-center gap-4">
-                <img src="/logo.png" alt="DiveVault logo" class="h-20 w-20 object-contain md:h-28 md:w-28" />
-                <span class="font-headline text-3xl font-bold tracking-tight text-primary md:text-5xl">DiveVault</span>
-              </div>
-              <div class="mt-3 h-px w-16 bg-primary/50"></div>
-            </div>
-          </header>
-
-          <main class="relative flex items-center justify-center px-6 md:px-8">
-            <div class="w-full max-w-md">
-              <div class="relative">
-                <div class="absolute -left-3 -top-3 h-8 w-8 border-l border-t border-primary/25 md:-left-5 md:-top-5 md:h-10 md:w-10"></div>
-                <div class="absolute -bottom-3 -right-3 h-8 w-8 border-b border-r border-primary/25 md:-bottom-5 md:-right-5 md:h-10 md:w-10"></div>
-
-                <section class="auth-panel relative overflow-hidden p-7 shadow-[0_24px_60px_rgba(0,15,29,0.45)] md:p-10">
-                  <div class="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/8 via-transparent to-transparent"></div>
-
-                <div class="relative">
-                  <div class="mb-9 text-center">
-                    <h1 class="font-headline text-2xl font-semibold tracking-[0.02em] text-on-surface md:text-3xl">
-                      {{ authTitle }}
-                    </h1>
-                  </div>
-
-                  <div v-if="authView === 'signin'" class="space-y-6">
-                    <SignIn
-                      routing="hash"
-                      sign-in-url="#signin"
-                      waitlist-url="#waitlist"
-                      :with-sign-up="false"
-                      :appearance="clerkAppearance"
-                    />
-                  </div>
-
-                  <div v-else-if="authView === 'recover'" class="space-y-5">
-                    <div v-if="recoveryMessage" class="rounded border border-primary/14 bg-primary/6 px-4 py-3 text-sm text-primary">
-                      {{ recoveryMessage }}
-                    </div>
-                    <div v-if="recoveryError" class="rounded border border-red-300/16 bg-red-400/7 px-4 py-3 text-sm text-red-100">
-                      {{ recoveryError }}
-                    </div>
-
-                    <div class="space-y-4">
-                      <label class="block">
-                        <span class="mb-2 block font-label text-[10px] font-bold tracking-[0.18em] text-on-surface-variant">
-                          Email Address
-                        </span>
-                        <input
-                          v-model.trim="recoveryEmail"
-                          type="email"
-                          autocomplete="email"
-                          class="w-full rounded-2xl border border-primary/8 bg-surface-container-highest/35 px-4 py-3 text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-variant/50 focus:border-primary/25"
-                          placeholder="diver@example.com"
-                        />
-                      </label>
-
-                      <template v-if="isRecoveryCodeStep">
-                        <label class="block">
-                          <span class="mb-2 block font-label text-[10px] font-bold tracking-[0.18em] text-on-surface-variant">
-                            Recovery Code
-                          </span>
-                          <input
-                            v-model.trim="recoveryCode"
-                            type="text"
-                            inputmode="numeric"
-                            autocomplete="one-time-code"
-                            class="w-full rounded-2xl border border-primary/8 bg-surface-container-highest/35 px-4 py-3 text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-variant/50 focus:border-primary/25"
-                            placeholder="Enter The Clerk Code"
-                          />
-                        </label>
-
-                        <label class="block">
-                          <span class="mb-2 block font-label text-[10px] font-bold tracking-[0.18em] text-on-surface-variant">
-                            New Password
-                          </span>
-                          <input
-                            v-model="recoveryPassword"
-                            type="password"
-                            autocomplete="new-password"
-                            class="w-full rounded-2xl border border-primary/8 bg-surface-container-highest/35 px-4 py-3 text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-variant/50 focus:border-primary/25"
-                            placeholder="Create A New Password"
-                          />
-                        </label>
-
-                        <label class="block">
-                          <span class="mb-2 block font-label text-[10px] font-bold tracking-[0.18em] text-on-surface-variant">
-                            Confirm Password
-                          </span>
-                          <input
-                            v-model="recoveryPasswordConfirm"
-                            type="password"
-                            autocomplete="new-password"
-                            class="w-full rounded-2xl border border-primary/8 bg-surface-container-highest/35 px-4 py-3 text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-variant/50 focus:border-primary/25"
-                            placeholder="Repeat The New Password"
-                          />
-                        </label>
-                      </template>
-                    </div>
-
-                    <div class="flex flex-col gap-3">
-                      <button
-                        type="button"
-                        :disabled="recoveryLoading"
-                        @click="isRecoveryCodeStep ? completePasswordRecovery() : startPasswordRecovery()"
-                        class="w-full rounded-[1.1rem] bg-[linear-gradient(135deg,#71c8ff_0%,#5faeff_45%,#5997ef_100%)] px-4 py-4 font-label text-[0.95rem] font-black tracking-[0.08em] text-[#031726] shadow-[0_14px_28px_rgba(43,116,181,0.22)] disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        {{ recoveryLoading ? "Working..." : (isRecoveryCodeStep ? "Reset Password" : "Send Recovery Code") }}
-                      </button>
-                    </div>
-                  </div>
-
-                  <div v-else class="space-y-6">
-                    <p class="text-center text-sm leading-6 text-on-surface-variant">
-                      DiveVault is currently in beta, so new access is being released gradually through the waitlist.
-                    </p>
-                    <Waitlist
-                      sign-in-url="#signin"
-                      after-join-waitlist-url="#signin"
-                      :appearance="clerkAppearance"
-                    />
-                  </div>
-
-                  <div class="mt-10 flex flex-col items-center gap-4 text-center">
-                    <button
-                      v-if="authView !== 'recover'"
-                      type="button"
-                      @click="openRecovery"
-                      class="font-label text-[10px] font-bold tracking-[0.12em] text-primary transition-colors hover:text-on-surface"
-                    >
-                      Recover Access
-                    </button>
-                    <button
-                      v-else
-                      type="button"
-                      @click="setAuthView('signin')"
-                      class="font-label text-[10px] font-bold tracking-[0.12em] text-primary transition-colors hover:text-on-surface"
-                    >
-                      Back To Login
-                    </button>
-                    <div class="h-px w-8 bg-outline-variant/30"></div>
-                    <p class="text-[11px] tracking-[0.04em] text-on-surface-variant">
-                      New Diver?
-                      <button
-                        v-if="authView !== 'waitlist'"
-                        type="button"
-                        @click="setAuthView('waitlist')"
-                        class="ml-1 font-label text-[10px] font-bold tracking-[0.12em] text-primary underline underline-offset-4 transition-colors hover:text-on-surface"
-                      >
-                        Join Waitlist
-                      </button>
-                      <button
-                        v-else
-                        type="button"
-                        @click="setAuthView('signin')"
-                        class="ml-1 font-label text-[10px] font-bold tracking-[0.12em] text-primary underline underline-offset-4 transition-colors hover:text-on-surface"
-                      >
-                        Back To Login
-                      </button>
-                    </p>
-                  </div>
-                </div>
-
-                  <div class="absolute bottom-0 left-0 h-1 w-full overflow-hidden bg-surface-container-highest">
-                    <div class="h-full w-1/3 bg-primary/40 animate-pulse"></div>
-                  </div>
-                </section>
-              </div>
-            </div>
-          </main>
+        <div class="space-y-3">
+          <input v-model.trim="email" type="email" placeholder="Email" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
+          <input v-if="authView !== 'recover'" v-model="password" type="password" placeholder="Password" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
+          <template v-if="authView === 'register'">
+            <input v-model.trim="firstName" type="text" placeholder="First name" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
+            <input v-model.trim="lastName" type="text" placeholder="Last name" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
+          </template>
+          <template v-if="authView === 'recover'">
+            <input v-model.trim="recoveryCode" type="text" placeholder="Recovery code" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
+            <input v-model="recoveryPassword" type="password" placeholder="New password" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
+          </template>
         </div>
 
-        <footer class="relative mt-10 px-6 pb-8 pt-8 md:px-12 md:pb-10">
-          <div class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 border-t border-primary/18 pt-8 text-center md:flex-row md:text-left">
-            <p class="text-[10px] tracking-[0.08em] text-on-surface-variant/50">
-              Copyright 2026
-            </p>
-            <a
-              href="https://github.com/jLemmings/DiveVault"
-              target="_blank"
-              rel="noreferrer"
-              class="inline-flex items-center gap-2 text-[10px] tracking-[0.08em] text-on-surface-variant/50 transition-all hover:text-primary hover:opacity-100"
-            >
-              <svg viewBox="0 0 24 24" aria-hidden="true" class="h-3.5 w-3.5 fill-current">
-                <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.38 7.86 10.9.58.11.79-.25.79-.56 0-.28-.01-1.2-.02-2.17-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.27-1.68-1.27-1.68-1.04-.71.08-.69.08-.69 1.15.08 1.75 1.18 1.75 1.18 1.02 1.76 2.68 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.23-1.28-5.23-5.68 0-1.25.45-2.27 1.18-3.08-.12-.29-.51-1.48.11-3.09 0 0 .97-.31 3.17 1.18a11.02 11.02 0 0 1 5.78 0c2.2-1.49 3.17-1.18 3.17-1.18.62 1.61.23 2.8.11 3.09.73.81 1.18 1.83 1.18 3.08 0 4.41-2.69 5.38-5.25 5.67.41.35.78 1.05.78 2.12 0 1.53-.01 2.77-.01 3.15 0 .31.21.68.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
-              </svg>
-              <span>jLemmings/DiveVault</span>
-            </a>
-          </div>
-        </footer>
+        <button v-if="authView === 'signin'" @click="submitSignIn" :disabled="loading" class="w-full rounded-xl bg-primary px-4 py-2 text-black font-semibold">Sign In</button>
+        <button v-if="authView === 'register'" @click="submitRegister" :disabled="loading" class="w-full rounded-xl bg-primary px-4 py-2 text-black font-semibold">Create Account</button>
+        <div v-if="authView === 'recover'" class="grid grid-cols-2 gap-2">
+          <button @click="sendRecoveryCode" :disabled="loading" class="rounded-xl border border-primary/30 px-3 py-2">Send Code</button>
+          <button @click="completeRecovery" :disabled="loading" class="rounded-xl bg-primary px-3 py-2 text-black font-semibold">Reset</button>
+        </div>
+
+        <div class="text-xs text-on-surface-variant flex gap-3">
+          <button @click="authView='signin'">Sign In</button>
+          <button @click="authView='register'">Create Account</button>
+          <button @click="authView='recover'">Recover</button>
+        </div>
       </div>
     </div>
   `

--- a/frontend/src/components/login.js
+++ b/frontend/src/components/login.js
@@ -2,25 +2,69 @@ import { loginWithPassword, registerUser } from "../auth.js";
 
 const AUTH_VIEW_SIGNIN = "signin";
 const AUTH_VIEW_REGISTER = "register";
-const AUTH_VIEW_RECOVER = "recover";
 
 export default {
   name: "LoginView",
   data() {
+    const inviteToken = typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("invite_token") || ""
+      : "";
     return {
       authView: AUTH_VIEW_SIGNIN,
       email: "",
       password: "",
       firstName: "",
       lastName: "",
+      inviteToken,
+      authStatus: {
+        initialized: false,
+        bootstrap_registration_open: false,
+        public_registration_enabled: false,
+        public_registration_open: false,
+        invite: null
+      },
       loading: false,
       error: "",
-      message: "",
-      recoveryCode: "",
-      recoveryPassword: ""
+      message: ""
     };
   },
+  computed: {
+    canRegister() {
+      return Boolean(this.authStatus.public_registration_open || this.authStatus.invite);
+    },
+    isInviteRegistration() {
+      return Boolean(this.inviteToken && this.authStatus.invite);
+    }
+  },
+  async mounted() {
+    await this.loadAuthStatus();
+  },
   methods: {
+    async loadAuthStatus() {
+      try {
+        const query = this.inviteToken ? `?invite_token=${encodeURIComponent(this.inviteToken)}` : "";
+        const response = await fetch(`/api/auth/status${query}`);
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(payload?.error || "Unable to load authentication state");
+        }
+        this.authStatus = {
+          initialized: Boolean(payload?.initialized),
+          bootstrap_registration_open: Boolean(payload?.bootstrap_registration_open),
+          public_registration_enabled: Boolean(payload?.public_registration_enabled),
+          public_registration_open: Boolean(payload?.public_registration_open),
+          invite: payload?.invite || null
+        };
+        if (this.authStatus.invite) {
+          this.authView = AUTH_VIEW_REGISTER;
+          this.email = this.authStatus.invite.email || this.email;
+          this.firstName = this.authStatus.invite.first_name || this.firstName;
+          this.lastName = this.authStatus.invite.last_name || this.lastName;
+        }
+      } catch (error) {
+        this.error = error?.message || "Unable to load sign-in options.";
+      }
+    },
     async submitSignIn() {
       this.loading = true;
       this.error = "";
@@ -41,55 +85,20 @@ export default {
           email: this.email.trim(),
           password: this.password,
           first_name: this.firstName.trim(),
-          last_name: this.lastName.trim()
+          last_name: this.lastName.trim(),
+          invite_token: this.inviteToken || undefined
         });
         this.authView = AUTH_VIEW_SIGNIN;
         this.message = "Account created. Sign in with your new credentials.";
+        if (this.inviteToken && typeof window !== "undefined") {
+          const url = new URL(window.location.href);
+          url.searchParams.delete("invite_token");
+          window.history.replaceState({}, "", url.toString());
+          this.inviteToken = "";
+          this.authStatus.invite = null;
+        }
       } catch (error) {
         this.error = error?.message || "Registration failed.";
-      } finally {
-        this.loading = false;
-      }
-    },
-    async sendRecoveryCode() {
-      this.loading = true;
-      this.error = "";
-      this.message = "";
-      try {
-        const response = await fetch("/api/auth/recover/start", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: this.email.trim() })
-        });
-        const payload = await response.json();
-        if (!response.ok) {
-          throw new Error(payload?.error || "Unable to start recovery");
-        }
-        this.message = `Recovery code generated: ${payload.recovery_code}`;
-      } catch (error) {
-        this.error = error?.message || "Unable to start recovery.";
-      } finally {
-        this.loading = false;
-      }
-    },
-    async completeRecovery() {
-      this.loading = true;
-      this.error = "";
-      this.message = "";
-      try {
-        const response = await fetch("/api/auth/recover/complete", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: this.email.trim(), code: this.recoveryCode.trim(), password: this.recoveryPassword })
-        });
-        const payload = await response.json();
-        if (!response.ok) {
-          throw new Error(payload?.error || "Unable to reset password");
-        }
-        this.authView = AUTH_VIEW_SIGNIN;
-        this.message = "Password reset complete. Sign in with your new password.";
-      } catch (error) {
-        this.error = error?.message || "Recovery failed.";
       } finally {
         this.loading = false;
       }
@@ -99,33 +108,25 @@ export default {
     <div class="min-h-screen flex items-center justify-center bg-surface px-4">
       <div class="w-full max-w-md rounded-2xl border border-primary/20 bg-surface-container-high/40 p-6 space-y-4">
         <h1 class="text-2xl font-semibold text-on-surface">DiveVault Authentication</h1>
+        <p v-if="isInviteRegistration" class="text-sm text-primary">This invitation reserves access for {{ authStatus.invite.email }}.</p>
         <p v-if="message" class="text-sm text-primary">{{ message }}</p>
         <p v-if="error" class="text-sm text-red-300">{{ error }}</p>
 
         <div class="space-y-3">
           <input v-model.trim="email" type="email" placeholder="Email" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
-          <input v-if="authView !== 'recover'" v-model="password" type="password" placeholder="Password" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
+          <input v-model="password" type="password" placeholder="Password" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
           <template v-if="authView === 'register'">
             <input v-model.trim="firstName" type="text" placeholder="First name" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
             <input v-model.trim="lastName" type="text" placeholder="Last name" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
-          </template>
-          <template v-if="authView === 'recover'">
-            <input v-model.trim="recoveryCode" type="text" placeholder="Recovery code" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
-            <input v-model="recoveryPassword" type="password" placeholder="New password" class="w-full rounded-xl border border-primary/20 bg-transparent px-3 py-2" />
           </template>
         </div>
 
         <button v-if="authView === 'signin'" @click="submitSignIn" :disabled="loading" class="w-full rounded-xl bg-primary px-4 py-2 text-black font-semibold">Sign In</button>
         <button v-if="authView === 'register'" @click="submitRegister" :disabled="loading" class="w-full rounded-xl bg-primary px-4 py-2 text-black font-semibold">Create Account</button>
-        <div v-if="authView === 'recover'" class="grid grid-cols-2 gap-2">
-          <button @click="sendRecoveryCode" :disabled="loading" class="rounded-xl border border-primary/30 px-3 py-2">Send Code</button>
-          <button @click="completeRecovery" :disabled="loading" class="rounded-xl bg-primary px-3 py-2 text-black font-semibold">Reset</button>
-        </div>
 
         <div class="text-xs text-on-surface-variant flex gap-3">
-          <button @click="authView='signin'">Sign In</button>
-          <button @click="authView='register'">Create Account</button>
-          <button @click="authView='recover'">Recover</button>
+          <button v-if="authView !== 'signin'" @click="authView='signin'">Sign In</button>
+          <button v-if="canRegister" @click="authView='register'">Create Account</button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/settings.js
+++ b/frontend/src/components/settings.js
@@ -403,8 +403,8 @@ export default {
     const { user } = useUser();
 
     return {
-      clerkGetToken: getToken,
-      clerkUser: user
+      authGetToken: getToken,
+      authUser: user
     };
   },
   data() {
@@ -477,13 +477,13 @@ export default {
       return Boolean(this.cliAuthCode);
     },
     currentUserEmail() {
-      return this.clerkUser?.primaryEmailAddress?.emailAddress
-        || this.clerkUser?.emailAddresses?.[0]?.emailAddress
+      return this.authUser?.primaryEmailAddress?.emailAddress
+        || this.authUser?.emailAddresses?.[0]?.emailAddress
         || "";
     },
     currentUserName() {
-      const firstName = this.clerkUser?.firstName?.trim() || "";
-      const lastName = this.clerkUser?.lastName?.trim() || "";
+      const firstName = this.authUser?.firstName?.trim() || "";
+      const lastName = this.authUser?.lastName?.trim() || "";
       return [firstName, lastName].filter(Boolean).join(" ") || this.currentUserEmail || "";
     },
     licenses() {
@@ -625,13 +625,13 @@ export default {
   watch: {
     currentUserName: {
       handler() {
-        this.syncClerkDefaults();
+        this.syncAuthenticationDefaults();
       },
       immediate: true
     },
     currentUserEmail: {
       handler() {
-        this.syncClerkDefaults();
+        this.syncAuthenticationDefaults();
       },
       immediate: true
     },
@@ -688,7 +688,7 @@ export default {
         this.setActiveSection(sectionId);
       }
     },
-    syncClerkDefaults() {
+    syncAuthenticationDefaults() {
       if (!this.settingsProfile.name && this.currentUserName) {
         this.settingsProfile.name = this.currentUserName;
       }
@@ -829,7 +829,7 @@ export default {
       return Array.isArray(collection) ? collection.findIndex((entry) => entry?.id === itemId) : -1;
     },
     async authenticatedFetch(resource, options = {}) {
-      const token = await this.clerkGetToken({ skipCache: true });
+      const token = await this.authGetToken({ skipCache: true });
       const headers = new Headers(options.headers || {});
       if (token) {
         headers.set("Authorization", `Bearer ${token}`);
@@ -851,7 +851,7 @@ export default {
         }
         this.settingsProfile = this.hydrateProfile(payload);
         this.notifyProfileUpdated(this.settingsProfile);
-        this.syncClerkDefaults();
+        this.syncAuthenticationDefaults();
         this.resetDraftsFromProfile();
       } catch (error) {
         this.profileError = error?.message || "Could not load the user profile.";
@@ -1621,7 +1621,7 @@ export default {
       this.desktopSyncError = "";
 
       try {
-        const token = await this.clerkGetToken({ skipCache: true });
+        const token = await this.authGetToken({ skipCache: true });
         const response = await fetch("/api/cli-auth/approve", {
           method: "POST",
           credentials: "include",

--- a/frontend/src/components/settings.js
+++ b/frontend/src/components/settings.js
@@ -182,6 +182,16 @@ function cloneProfile(profile = {}) {
   };
 }
 
+function emptyInviteDraft() {
+  return {
+    email: "",
+    first_name: "",
+    last_name: "",
+    role: "user",
+    expires_in_days: 7
+  };
+}
+
 function editableLicensePayload(license) {
   return {
     id: license.id,
@@ -264,6 +274,7 @@ export const SETTINGS_SECTIONS = [
   { id: "buddies", label: "Buddies", icon: "groups", description: "Saved dive partners" },
   { id: "dive-guide", label: "Dive Guide", icon: "support_agent", description: "Guides and instructors" },
   { id: "data-management", label: "Data Management", icon: "database", description: "Exports and sync access" },
+  { id: "manage-users", label: "Manage Users", icon: "admin_panel_settings", description: "Invites and access control" },
   { id: "backup", label: "Backup", icon: "archive", description: "Full backup import and export" }
 ];
 
@@ -440,6 +451,20 @@ export default {
       dataManagementStatus: "",
       dataManagementError: "",
       dataManagementAction: "",
+      manageUsersLoading: false,
+      manageUsersSaving: false,
+      manageUsersStatus: "",
+      manageUsersError: "",
+      authSettings: {
+        public_registration_enabled: false,
+        owner_user_id: "",
+        user_count: 0,
+        initialized: false
+      },
+      authUsers: [],
+      inviteDraft: emptyInviteDraft(),
+      inviteSubmitting: false,
+      latestInviteUrl: "",
       desktopSyncStatus: "",
       desktopSyncError: "",
       desktopSyncApproving: false,
@@ -475,6 +500,9 @@ export default {
   computed: {
     hasCliAuthCode() {
       return Boolean(this.cliAuthCode);
+    },
+    canManageUsers() {
+      return Boolean(this.authUser?.isOwner);
     },
     currentUserEmail() {
       return this.authUser?.primaryEmailAddress?.emailAddress
@@ -579,20 +607,24 @@ export default {
       return `${window.location.origin}/public/${this.settingsProfile.public_slug}`;
     },
     settingsOverviewStats() {
-      return [
+      const stats = [
         { id: "licenses", label: "Licenses", value: this.licenses.length, icon: "workspace_premium" },
         { id: "sites", label: "Dive Sites", value: this.diveSites.length, icon: "pin_drop" },
         { id: "buddies", label: "Buddies", value: this.buddies.length, icon: "groups" },
         { id: "guides", label: "Guides", value: this.guides.length, icon: "support_agent" }
       ];
+      if (this.canManageUsers) {
+        stats.push({ id: "users", label: "Users", value: this.authUsers.length, icon: "group_add" });
+      }
+      return stats;
     },
     settingsSections() {
-      return SETTINGS_SECTIONS;
+      return SETTINGS_SECTIONS.filter((section) => section.id !== "manage-users" || this.canManageUsers);
     },
     activeSettingsSection() {
-      return SETTINGS_SECTIONS.some((section) => section.id === this.activeSection)
+      return this.settingsSections.some((section) => section.id === this.activeSection)
         ? this.activeSection
-        : (SETTINGS_SECTIONS[0]?.id || "diver-details");
+        : (this.settingsSections[0]?.id || "diver-details");
     },
     isDataManagementBusy() {
       return Boolean(this.dataManagementAction);
@@ -620,9 +652,25 @@ export default {
         guide: "Save Guide"
       };
       return labelByType[this.pendingCreationType] || "Save";
+    },
+    ownerUserId() {
+      return this.authSettings.owner_user_id || "";
     }
   },
   watch: {
+    canManageUsers: {
+      async handler(value) {
+        if (value) {
+          await this.fetchUserManagement();
+          return;
+        }
+        this.authUsers = [];
+        this.latestInviteUrl = "";
+        this.manageUsersStatus = "";
+        this.manageUsersError = "";
+      },
+      immediate: true
+    },
     currentUserName: {
       handler() {
         this.syncAuthenticationDefaults();
@@ -864,6 +912,192 @@ export default {
       if (payload?.error) return payload.error;
       const bodyText = await response.text().catch(() => "");
       return bodyText || fallbackMessage || `API returned ${response.status}`;
+    },
+    async fetchUserManagement() {
+      if (!this.canManageUsers) {
+        return;
+      }
+      this.manageUsersLoading = true;
+      this.manageUsersError = "";
+      try {
+        const [settingsResponse, usersResponse] = await Promise.all([
+          this.authenticatedFetch("/api/auth/settings"),
+          this.authenticatedFetch("/api/users")
+        ]);
+        if (!settingsResponse.ok) {
+          throw new Error(await this.readErrorResponse(settingsResponse, "Could not load authentication settings."));
+        }
+        if (!usersResponse.ok) {
+          throw new Error(await this.readErrorResponse(usersResponse, "Could not load the user directory."));
+        }
+        const settingsPayload = await settingsResponse.json().catch(() => ({}));
+        const usersPayload = await usersResponse.json().catch(() => ({}));
+        this.authSettings = {
+          public_registration_enabled: Boolean(settingsPayload?.public_registration_enabled),
+          owner_user_id: settingsPayload?.owner_user_id || "",
+          user_count: Number(settingsPayload?.user_count || 0),
+          initialized: Boolean(settingsPayload?.initialized)
+        };
+        this.authUsers = Array.isArray(usersPayload?.users) ? usersPayload.users : [];
+      } catch (error) {
+        this.manageUsersError = error?.message || "Could not load user management.";
+      } finally {
+        this.manageUsersLoading = false;
+      }
+    },
+    async savePublicRegistrationSetting() {
+      this.manageUsersSaving = true;
+      this.manageUsersError = "";
+      this.manageUsersStatus = "";
+      try {
+        const response = await this.authenticatedFetch("/api/auth/settings", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            public_registration_enabled: Boolean(this.authSettings.public_registration_enabled)
+          })
+        });
+        if (!response.ok) {
+          throw new Error(await this.readErrorResponse(response, "Could not update public registration."));
+        }
+        const payload = await response.json().catch(() => ({}));
+        this.authSettings = {
+          public_registration_enabled: Boolean(payload?.public_registration_enabled),
+          owner_user_id: payload?.owner_user_id || "",
+          user_count: Number(payload?.user_count || this.authUsers.length),
+          initialized: Boolean(payload?.initialized)
+        };
+        this.manageUsersStatus = this.authSettings.public_registration_enabled
+          ? "Public registration enabled."
+          : "Public registration disabled.";
+      } catch (error) {
+        this.manageUsersError = error?.message || "Could not update public registration.";
+      } finally {
+        this.manageUsersSaving = false;
+      }
+    },
+    async createUserInvite() {
+      this.inviteSubmitting = true;
+      this.manageUsersError = "";
+      this.manageUsersStatus = "";
+      try {
+        const response = await this.authenticatedFetch("/api/auth/invitations", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(this.inviteDraft)
+        });
+        if (!response.ok) {
+          throw new Error(await this.readErrorResponse(response, "Could not create the invitation."));
+        }
+        const payload = await response.json().catch(() => ({}));
+        const inviteUrl = String(payload?.invite_url || "");
+        this.latestInviteUrl = inviteUrl.startsWith("/")
+          ? `${window.location.origin}${inviteUrl}`
+          : inviteUrl;
+        this.manageUsersStatus = `Invitation created for ${this.inviteDraft.email.trim()}.`;
+        this.inviteDraft = {
+          ...emptyInviteDraft(),
+          role: this.inviteDraft.role,
+          expires_in_days: this.inviteDraft.expires_in_days
+        };
+        await this.fetchUserManagement();
+      } catch (error) {
+        this.manageUsersError = error?.message || "Could not create the invitation.";
+      } finally {
+        this.inviteSubmitting = false;
+      }
+    },
+    async copyLatestInviteUrl() {
+      if (!this.latestInviteUrl || !navigator?.clipboard?.writeText) {
+        this.manageUsersError = "Clipboard access is unavailable in this browser.";
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(this.latestInviteUrl);
+        this.manageUsersStatus = "Invitation link copied.";
+        this.manageUsersError = "";
+      } catch (_error) {
+        this.manageUsersError = "Could not copy the invitation link.";
+      }
+    },
+    async toggleManagedUserActive(user) {
+      if (!user?.id || user.id === this.ownerUserId) {
+        return;
+      }
+      this.manageUsersSaving = true;
+      this.manageUsersError = "";
+      this.manageUsersStatus = "";
+      try {
+        const response = await this.authenticatedFetch(`/api/users/${user.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ is_active: !Boolean(user.is_active) })
+        });
+        if (!response.ok) {
+          throw new Error(await this.readErrorResponse(response, "Could not update the user status."));
+        }
+        const payload = await response.json().catch(() => ({}));
+        const updatedUser = payload?.user || user;
+        this.manageUsersStatus = updatedUser.is_active
+          ? `Reactivated ${updatedUser.email}.`
+          : `Deactivated ${updatedUser.email}.`;
+        await this.fetchUserManagement();
+      } catch (error) {
+        this.manageUsersError = error?.message || "Could not update the user status.";
+      } finally {
+        this.manageUsersSaving = false;
+      }
+    },
+    async toggleManagedUserRole(user) {
+      if (!user?.id || user.id === this.ownerUserId) {
+        return;
+      }
+      const nextRole = user.role === "admin" ? "user" : "admin";
+      this.manageUsersSaving = true;
+      this.manageUsersError = "";
+      this.manageUsersStatus = "";
+      try {
+        const response = await this.authenticatedFetch(`/api/users/${user.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ role: nextRole })
+        });
+        if (!response.ok) {
+          throw new Error(await this.readErrorResponse(response, "Could not update the user role."));
+        }
+        this.manageUsersStatus = `${user.email} is now ${nextRole}.`;
+        await this.fetchUserManagement();
+      } catch (error) {
+        this.manageUsersError = error?.message || "Could not update the user role.";
+      } finally {
+        this.manageUsersSaving = false;
+      }
+    },
+    async deleteManagedUser(user) {
+      if (!user?.id || user.id === this.ownerUserId) {
+        return;
+      }
+      const confirmed = window.confirm(`Delete ${user.email}? This cannot be undone.`);
+      if (!confirmed) {
+        return;
+      }
+      this.manageUsersSaving = true;
+      this.manageUsersError = "";
+      this.manageUsersStatus = "";
+      try {
+        const response = await this.authenticatedFetch(`/api/users/${user.id}`, {
+          method: "DELETE"
+        });
+        if (!response.ok) {
+          throw new Error(await this.readErrorResponse(response, "Could not delete the user."));
+        }
+        this.manageUsersStatus = `${user.email} was removed.`;
+        await this.fetchUserManagement();
+      } catch (error) {
+        this.manageUsersError = error?.message || "Could not delete the user.";
+      } finally {
+        this.manageUsersSaving = false;
+      }
     },
     downloadBlob(blob, filename) {
       const objectUrl = URL.createObjectURL(blob);
@@ -2562,6 +2796,161 @@ export default {
               </button>
               <p v-if="desktopSyncStatus" class="mt-3 text-sm text-primary">{{ desktopSyncStatus }}</p>
               <p v-if="desktopSyncError" class="mt-3 text-sm text-error">{{ desktopSyncError }}</p>
+            </div>
+          </div>
+
+          <div v-if="activeSettingsSection === 'manage-users' && canManageUsers" class="settings-panel settings-card">
+            <div class="settings-card-header">
+              <div>
+                <p class="font-label text-[10px] font-bold uppercase tracking-[0.24em] text-primary">Manage Users</p>
+                <h4 class="mt-2 font-headline text-3xl font-bold tracking-tight text-on-surface">Invites And Access Control</h4>
+                <p class="mt-3 max-w-3xl text-sm leading-7 text-secondary">Invite new divers, review who can sign in, and control whether self-registration is open on this instance.</p>
+              </div>
+            </div>
+
+            <div v-if="manageUsersStatus" class="settings-feedback border-primary/20 bg-primary/10 text-primary">{{ manageUsersStatus }}</div>
+            <div v-if="manageUsersError" class="settings-feedback border-error/20 bg-error-container/20 text-on-error-container">{{ manageUsersError }}</div>
+
+            <div class="settings-action-grid">
+              <div class="settings-action-card">
+                <div class="flex items-start justify-between gap-4">
+                  <div>
+                    <div class="flex items-center gap-3">
+                      <span class="material-symbols-outlined text-primary">how_to_reg</span>
+                      <p class="font-headline text-xl font-bold text-on-surface">Public Registration</p>
+                    </div>
+                    <p class="mt-3 text-sm leading-6 text-secondary">Keep sign-up closed and use invitations only, or open self-registration for this DiveVault instance.</p>
+                  </div>
+                  <span class="settings-chip" :class="authSettings.public_registration_enabled ? 'is-accent' : ''">
+                    {{ authSettings.public_registration_enabled ? 'Open' : 'Invite only' }}
+                  </span>
+                </div>
+                <label class="mt-5 flex items-start gap-4 rounded-2xl border border-primary/10 bg-background/20 px-4 py-4">
+                  <input v-model="authSettings.public_registration_enabled" type="checkbox" class="mt-1 h-5 w-5 rounded border-primary/20 bg-surface-container-high text-primary focus:ring-primary/30" />
+                  <div>
+                    <p class="text-sm font-semibold text-on-surface">Allow direct account creation</p>
+                    <p class="mt-1 text-sm leading-6 text-secondary">When disabled, new users must come through an invite link from the instance owner.</p>
+                  </div>
+                </label>
+                <button @click="savePublicRegistrationSetting" :disabled="manageUsersSaving || manageUsersLoading" class="settings-button settings-button-primary mt-5">
+                  {{ manageUsersSaving ? 'Saving Access Policy' : 'Save Access Policy' }}
+                </button>
+              </div>
+
+              <div class="settings-action-card">
+                <div class="flex items-start justify-between gap-4">
+                  <div>
+                    <div class="flex items-center gap-3">
+                      <span class="material-symbols-outlined text-primary">person_add</span>
+                      <p class="font-headline text-xl font-bold text-on-surface">Invite User</p>
+                    </div>
+                    <p class="mt-3 text-sm leading-6 text-secondary">Create a one-time sign-up link for a second diver or admin on this instance.</p>
+                  </div>
+                  <span class="settings-chip">{{ authUsers.length }} users</span>
+                </div>
+                <div class="mt-5 grid gap-4 md:grid-cols-2">
+                  <label class="space-y-2 md:col-span-2">
+                    <span class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Email</span>
+                    <input v-model.trim="inviteDraft.email" type="email" class="settings-input" placeholder="second-user@example.com" />
+                  </label>
+                  <label class="space-y-2">
+                    <span class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">First Name</span>
+                    <input v-model.trim="inviteDraft.first_name" type="text" class="settings-input" placeholder="First name" />
+                  </label>
+                  <label class="space-y-2">
+                    <span class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Last Name</span>
+                    <input v-model.trim="inviteDraft.last_name" type="text" class="settings-input" placeholder="Last name" />
+                  </label>
+                  <label class="space-y-2">
+                    <span class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Role</span>
+                    <select v-model="inviteDraft.role" class="settings-input">
+                      <option value="user">User</option>
+                      <option value="admin">Admin</option>
+                    </select>
+                  </label>
+                  <label class="space-y-2">
+                    <span class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Expires In Days</span>
+                    <input v-model.number="inviteDraft.expires_in_days" type="number" min="1" max="30" class="settings-input" />
+                  </label>
+                </div>
+                <div class="mt-5 flex flex-wrap gap-3">
+                  <button @click="createUserInvite" :disabled="inviteSubmitting || manageUsersLoading" class="settings-button settings-button-primary">
+                    {{ inviteSubmitting ? 'Creating Invite' : 'Create Invite' }}
+                  </button>
+                  <button v-if="latestInviteUrl" @click="copyLatestInviteUrl" class="settings-button settings-button-secondary">Copy Invite Link</button>
+                </div>
+                <div v-if="latestInviteUrl" class="mt-5 rounded-2xl border border-primary/10 bg-background/20 px-4 py-4">
+                  <p class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Latest Invite Link</p>
+                  <p class="mt-2 break-all text-sm font-semibold text-primary">{{ latestInviteUrl }}</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-6 space-y-4">
+              <div class="flex items-center justify-between gap-4">
+                <div>
+                  <p class="font-label text-[10px] font-bold uppercase tracking-[0.24em] text-primary">Current Users</p>
+                  <p class="mt-2 text-sm text-secondary">The owner account stays protected. Other users can be promoted, disabled, or removed here.</p>
+                </div>
+                <button @click="fetchUserManagement" :disabled="manageUsersLoading || manageUsersSaving" class="settings-button settings-button-secondary">
+                  {{ manageUsersLoading ? 'Refreshing' : 'Refresh' }}
+                </button>
+              </div>
+
+              <div v-if="manageUsersLoading && authUsers.length === 0" class="settings-empty-state">
+                <p class="font-headline text-lg font-bold">Loading users</p>
+                <p class="mt-2 text-sm text-secondary">Reading the current instance access list.</p>
+              </div>
+
+              <div v-else-if="authUsers.length === 0" class="settings-empty-state">
+                <p class="font-headline text-lg font-bold">No users found</p>
+                <p class="mt-2 text-sm text-secondary">Create an invitation above to add another diver.</p>
+              </div>
+
+              <div v-else class="space-y-4">
+                <article v-for="user in authUsers" :key="user.id" class="settings-item-card">
+                  <div class="settings-item-header">
+                    <div class="min-w-0">
+                      <p class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">{{ user.id === ownerUserId ? 'Owner' : 'User' }}</p>
+                      <h5 class="mt-2 font-headline text-2xl font-bold tracking-tight text-on-surface">{{ user.email }}</h5>
+                      <div class="settings-chip-row mt-3">
+                        <span class="settings-chip" :class="user.role === 'admin' ? 'is-accent' : ''">{{ user.role }}</span>
+                        <span class="settings-chip" :class="user.is_active ? 'is-accent' : ''">{{ user.is_active ? 'Active' : 'Inactive' }}</span>
+                        <span v-if="user.id === ownerUserId" class="settings-chip">Protected</span>
+                      </div>
+                    </div>
+
+                    <div v-if="user.id !== ownerUserId" class="settings-toolbar">
+                      <button @click="toggleManagedUserRole(user)" :disabled="manageUsersSaving" class="settings-button settings-button-secondary">
+                        {{ user.role === 'admin' ? 'Make User' : 'Make Admin' }}
+                      </button>
+                      <button @click="toggleManagedUserActive(user)" :disabled="manageUsersSaving" class="settings-button settings-button-secondary">
+                        {{ user.is_active ? 'Deactivate' : 'Activate' }}
+                      </button>
+                      <button @click="deleteManagedUser(user)" :disabled="manageUsersSaving" class="settings-button settings-button-danger">Delete</button>
+                    </div>
+                  </div>
+
+                  <div class="settings-detail-grid">
+                    <div class="settings-info-card">
+                      <p class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Name</p>
+                      <p class="mt-2 text-base font-semibold text-on-surface">{{ displayValue([user.first_name, user.last_name].filter(Boolean).join(' ')) }}</p>
+                    </div>
+                    <div class="settings-info-card">
+                      <p class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Last Login</p>
+                      <p class="mt-2 text-base font-semibold text-on-surface">{{ formatDateTime(user.last_login_at) }}</p>
+                    </div>
+                    <div class="settings-info-card">
+                      <p class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Created</p>
+                      <p class="mt-2 text-base font-semibold text-on-surface">{{ formatDateTime(user.created_at) }}</p>
+                    </div>
+                    <div class="settings-info-card">
+                      <p class="font-label text-[10px] font-bold uppercase tracking-[0.18em] text-secondary">Updated</p>
+                      <p class="mt-2 text-base font-semibold text-on-surface">{{ formatDateTime(user.updated_at) }}</p>
+                    </div>
+                  </div>
+                </article>
+              </div>
             </div>
           </div>
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -2,43 +2,12 @@ import { createApp } from "vue";
 import "leaflet/dist/leaflet.css";
 
 import App from "./app.js";
-import { hasTestAuthState, installAuthPlugin } from "./auth.js";
+import { initializeAuth } from "./auth.js";
 import "./styles.css";
 
-async function loadRuntimeConfig() {
-  if (window.__APP_CONFIG__) {
-    return window.__APP_CONFIG__;
-  }
-
-  await new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.src = "/config.js";
-    script.async = false;
-    script.onload = resolve;
-    script.onerror = () => reject(new Error("Unable to load /config.js from the backend."));
-    document.head.append(script);
-  });
-
-  return window.__APP_CONFIG__;
-}
-
 async function bootstrap() {
-  const publishableKey = (await loadRuntimeConfig())?.clerkPublishableKey;
-
-  if (!publishableKey && !hasTestAuthState()) {
-    throw new Error("Add VITE_CLERK_PUBLISHABLE_KEY to the backend environment before starting the app.");
-  }
-
-  const app = createApp(App);
-
-  installAuthPlugin(app, {
-    publishableKey,
-    afterSignOutUrl: "/",
-    signInFallbackRedirectUrl: "/",
-    signUpFallbackRedirectUrl: "/"
-  });
-
-  app.mount("#app");
+  await initializeAuth();
+  createApp(App).mount("#app");
 }
 
 bootstrap();

--- a/frontend/tests/app.spec.js
+++ b/frontend/tests/app.spec.js
@@ -8,19 +8,6 @@ test("renders login flows with the local Clerk test stub", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Sign In Test Diver" })).toBeVisible();
-
-  await page.getByRole("button", { name: "Recover Access" }).click();
-  await expect(page.getByRole("heading", { name: "Recover Access" })).toBeVisible();
-  await page.getByPlaceholder("diver@example.com").fill("diver@example.com");
-  await page.getByRole("button", { name: "Send Recovery Code" }).click();
-  await expect(page.getByText("Recovery code sent to diver@example.com.")).toBeVisible();
-
-  await page.getByPlaceholder("Enter The Clerk Code").fill("123456");
-  await page.getByPlaceholder("Create A New Password").fill("DiverPass123!");
-  await page.getByPlaceholder("Repeat The New Password").fill("DiverPass123!");
-  await page.getByRole("button", { name: "Reset Password" }).click();
-
-  await expect(page.getByText("Dive Overview")).toBeVisible();
 });
 
 test("covers dashboard, logs, dive detail, and logbook editing", async ({ page }) => {

--- a/frontend/tests/app.spec.js
+++ b/frontend/tests/app.spec.js
@@ -2,12 +2,32 @@ import { expect, test } from "@playwright/test";
 
 import { gotoAndWait, installAppMocks } from "./helpers/app-fixtures.js";
 
-test("renders login flows with the local Clerk test stub", async ({ page }) => {
-  await installAppMocks(page, { signedIn: false });
+test("renders login flows with the local auth screen", async ({ page }) => {
+  await installAppMocks(page, {
+    signedIn: false,
+    authStatus: {
+      initialized: false,
+      bootstrap_registration_open: true,
+      public_registration_enabled: false,
+      public_registration_open: true
+    }
+  });
   await gotoAndWait(page);
 
-  await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Sign In Test Diver" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "DiveVault Authentication" })).toBeVisible();
+  await expect(page.getByPlaceholder("Email")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create Account" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Create Account" }).last().click();
+  await expect(page.getByPlaceholder("First name")).toBeVisible();
+  await expect(page.getByPlaceholder("Last name")).toBeVisible();
+
+  await page.getByRole("button", { name: "Sign In" }).last().click();
+  await page.getByPlaceholder("Email").fill("avery@example.com");
+  await page.getByPlaceholder("Password").fill("Password123!");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  await expect(page.getByText("Dive Overview")).toBeVisible();
 });
 
 test("covers dashboard, logs, dive detail, and logbook editing", async ({ page }) => {

--- a/frontend/tests/helpers/app-fixtures.js
+++ b/frontend/tests/helpers/app-fixtures.js
@@ -6,8 +6,11 @@ function clone(value) {
 
 function baseUser() {
   return {
+    id: "user_avery",
     firstName: "Avery",
     lastName: "Marlow",
+    role: "admin",
+    isOwner: false,
     primaryEmailAddress: {
       emailAddress: "avery@example.com"
     },
@@ -16,6 +19,34 @@ function baseUser() {
         emailAddress: "avery@example.com"
       }
     ]
+  };
+}
+
+function baseAuthStatus(overrides = {}) {
+  return {
+    initialized: true,
+    bootstrap_registration_open: false,
+    public_registration_enabled: false,
+    public_registration_open: false,
+    invite: null,
+    user_count: 1,
+    ...overrides
+  };
+}
+
+function authMePayload(user = baseUser(), overrides = {}) {
+  const email = user?.primaryEmailAddress?.emailAddress
+    || user?.emailAddresses?.[0]?.emailAddress
+    || "";
+  return {
+    user_id: user?.id || "user_avery",
+    session_id: "session_playwright",
+    email,
+    first_name: user?.firstName || "",
+    last_name: user?.lastName || "",
+    role: user?.role || "user",
+    is_owner: Boolean(user?.isOwner),
+    ...overrides
   };
 }
 
@@ -241,9 +272,14 @@ async function fulfillJson(route, payload, status = 200) {
 
 async function setupTestState(page, { signedIn = true, user = baseUser() } = {}) {
   await page.addInitScript((state) => {
-    window.__DIVEVAULT_TEST_STATE__ = state;
     window.scrollTo = () => {};
     window.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+    const storageKey = "divevault_auth_token";
+    if (state.signedIn && state.token) {
+      window.localStorage.setItem(storageKey, state.token);
+    } else {
+      window.localStorage.removeItem(storageKey);
+    }
     const clipboardState = { value: "" };
     Object.defineProperty(window.navigator, "clipboard", {
       configurable: true,
@@ -269,21 +305,43 @@ async function installAppMocks(page, options = {}) {
     ...baseData(),
     ...(options.data ? clone(options.data) : {})
   };
+  const signedIn = options.signedIn ?? true;
+  const user = options.user || baseUser();
+  const authStatus = baseAuthStatus(options.authStatus);
+  const authUsers = clone(options.authUsers || [
+    {
+      id: user.id || "user_avery",
+      email: user.primaryEmailAddress?.emailAddress || user.emailAddresses?.[0]?.emailAddress || "avery@example.com",
+      first_name: user.firstName || "",
+      last_name: user.lastName || "",
+      role: user.role || "user",
+      is_active: true,
+      created_at: "2026-04-01T09:00:00Z",
+      updated_at: "2026-04-01T09:00:00Z",
+      last_login_at: "2026-04-07T10:00:00Z"
+    }
+  ]);
+  const session = {
+    signedIn,
+    token: options.token || "playwright-token",
+    user
+  };
   data.dives = clone(options.data?.dives || data.dives);
   data.profile = clone(options.data?.profile || data.profile);
   data.stats = clone(options.data?.stats || data.stats);
   refreshStats(data);
 
   await setupTestState(page, {
-    signedIn: options.signedIn ?? true,
-    user: options.user || baseUser()
+    signedIn,
+    user,
+    token: session.token
   });
 
   await page.route("**/config.js", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/javascript",
-      body: "window.__APP_CONFIG__ = { clerkPublishableKey: 'pk_test_local' };"
+      body: "window.__APP_CONFIG__ = { authEnabled: true };"
     });
   });
 
@@ -294,6 +352,104 @@ async function installAppMocks(page, options = {}) {
 
     if (pathname === "/api/health") {
       await fulfillJson(route, { ok: data.health }, data.health ? 200 : 503);
+      return;
+    }
+
+    if (pathname === "/api/auth/status" && request.method() === "GET") {
+      await fulfillJson(route, clone(authStatus));
+      return;
+    }
+
+    if (pathname === "/api/auth/login" && request.method() === "POST") {
+      const payload = request.postDataJSON ? request.postDataJSON() : JSON.parse(request.postData() || "{}");
+      if (!payload?.email || !payload?.password) {
+        await fulfillJson(route, { error: "Email and password are required." }, 400);
+        return;
+      }
+      await fulfillJson(route, { token: session.token });
+      return;
+    }
+
+    if (pathname === "/api/auth/register" && request.method() === "POST") {
+      const payload = request.postDataJSON ? request.postDataJSON() : JSON.parse(request.postData() || "{}");
+      if (!payload?.email || !payload?.password) {
+        await fulfillJson(route, { error: "Email and password are required." }, 400);
+        return;
+      }
+      await fulfillJson(route, {
+        created: true,
+        email: payload.email,
+        first_name: payload.first_name || "",
+        last_name: payload.last_name || ""
+      }, 201);
+      return;
+    }
+
+    if (pathname === "/api/auth/me" && request.method() === "GET") {
+      const authorization = request.headers()["authorization"] || "";
+      const token = authorization.toLowerCase().startsWith("bearer ")
+        ? authorization.split(" ", 2)[1]
+        : "";
+      if (!signedIn && token !== session.token) {
+        await fulfillJson(route, { error: "Session expired" }, 401);
+        return;
+      }
+      if (token !== session.token) {
+        await fulfillJson(route, { error: "Session expired" }, 401);
+        return;
+      }
+      await fulfillJson(route, authMePayload(user));
+      return;
+    }
+
+    if (pathname === "/api/auth/password" && request.method() === "PUT") {
+      await fulfillJson(route, { updated: true });
+      return;
+    }
+
+    if (pathname === "/api/users" && request.method() === "GET") {
+      await fulfillJson(route, {
+        settings: {
+          initialized: authStatus.initialized,
+          public_registration_enabled: authStatus.public_registration_enabled,
+          owner_user_id: authUsers[0]?.id || "",
+          user_count: authUsers.length
+        },
+        users: clone(authUsers)
+      });
+      return;
+    }
+
+    if (pathname === "/api/auth/invitations" && request.method() === "POST") {
+      const payload = request.postDataJSON ? request.postDataJSON() : JSON.parse(request.postData() || "{}");
+      await fulfillJson(route, {
+        invite_url: `http://localhost:4173/?invite_token=test-invite-token&email=${encodeURIComponent(payload?.email || "")}`,
+        token: "test-invite-token"
+      }, 201);
+      return;
+    }
+
+    const userMatch = pathname.match(/^\/api\/users\/([^/]+)$/);
+    if (userMatch && request.method() === "PUT") {
+      const payload = request.postDataJSON ? request.postDataJSON() : JSON.parse(request.postData() || "{}");
+      const index = authUsers.findIndex((entry) => entry.id === userMatch[1]);
+      if (index === -1) {
+        await fulfillJson(route, { error: "User not found" }, 404);
+        return;
+      }
+      authUsers[index] = { ...authUsers[index], ...payload };
+      await fulfillJson(route, clone(authUsers[index]));
+      return;
+    }
+
+    if (userMatch && request.method() === "DELETE") {
+      const index = authUsers.findIndex((entry) => entry.id === userMatch[1]);
+      if (index === -1) {
+        await fulfillJson(route, { error: "User not found" }, 404);
+        return;
+      }
+      authUsers.splice(index, 1);
+      await fulfillJson(route, { deleted: true, user_id: userMatch[1] });
       return;
     }
 


### PR DESCRIPTION
### Motivation

- Replace the external Clerk dependency with an integrated first-party authentication system using signed JWT session tokens to simplify deployment and allow local user management.
- Provide a migration path for existing Clerk users so per-user data retains the same owner IDs.

### Description

- Implemented first-party auth on the backend: added `auth_users` and `auth_password_reset_codes` schema, bumped `CURRENT_SCHEMA_VERSION` to 6, and added migration logic in `postgres_store.py` to create the new tables and indexes.
- Added password handling and session issuance: `hash_password`/`verify_password` (scrypt), `issue_session_token`, and a `DiveVaultAuthTokenVerifier` to validate HS256 session tokens; replaced Clerk verifier usage across the server and wired `server.auth_verifier` config/flags.
- Exposed new auth HTTP endpoints: `/api/auth/register`, `/api/auth/login`, `/api/auth/recover/start`, `/api/auth/recover/complete`, and `/api/auth/me`, plus admin user management endpoints (`/api/users`, `/api/users/:id` for create/update/delete) and password change (`PUT /api/auth/password`).
- Added a one-off migration/import script `backend/migrations/migrate_clerk_users_to_auth.py` to import exported Clerk users into `auth_users` while preserving original user IDs and optionally generating temporary passwords.
- Frontend removed the `@clerk/vue` dependency and implemented a lightweight first-party client: `auth.js` handles token storage, session loading (`/api/auth/me`), `loginWithPassword`, `registerUser`, and recovery flows; UI components (login, settings, app) were updated to use the new auth API and token getters; `frontend/package.json` and lockfile updated to remove Clerk.
- README updated to reflect new environment variables and documented the manual Clerk user migration steps.

### Testing

- Ran the backend test suite with `python -m pytest -q backend/tests` and verified the test run completed without failures.
- Built the frontend locally with `npm run build` to confirm the app compiles after removing the Clerk dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da316a696883279a3b6f2bb1adcef4)